### PR TITLE
Generalize loss_function serializer

### DIFF
--- a/pymilo/transporters/lossfunction_transporter.py
+++ b/pymilo/transporters/lossfunction_transporter.py
@@ -25,10 +25,10 @@ class LossFunctionTransporter(AbstractTransporter):
         :return: pymilo serialized output of data[key]
         """
         if (
-            (model_type == "SGDClassifier" and key == "loss_function_") or
-            (model_type == "SGDOneClassSVM" and key == "loss_function_") or
-            (model_type == "Perceptron" and key == "loss_function_") or
-            (model_type == "PassiveAggressiveClassifier" and key == "loss_function_")
+            (model_type == "SGDClassifier" and (key == "loss_function_" or key == "_loss_function_")) or
+            (model_type == "SGDOneClassSVM" and (key == "loss_function_" or key == "_loss_function_")) or
+            (model_type == "Perceptron" and (key == "loss_function_" or key == "_loss_function_")) or
+            (model_type == "PassiveAggressiveClassifier" and (key == "loss_function_" or key == "_loss_function_"))
         ):
             data[key] = {
                 "loss": data["loss"]


### PR DESCRIPTION
#### Reference Issues/PRs
#73 
#### What does this implement/fix? Explain your changes.
in 1.4.0 version of scikit learn, "_loss_function_" is used instead of "loss_function_".
#### Any other comments?

