### PR TITLE
Feature/ensemble_transporters

### DIFF
--- a/pymilo/transporters/binmapper_transporter.py
+++ b/pymilo/transporters/binmapper_transporter.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+"""PyMilo Loss function transporter."""
+from sklearn.ensemble._hist_gradient_boosting.binning import _BinMapper
+from ..utils.util import is_primitive, check_str_in_iterable
+from .transporter import AbstractTransporter
+from .general_data_structure_transporter import GeneralDataStructureTransporter
+
+
+class BinMapperTransporter(AbstractTransporter):
+    """Customized PyMilo Transporter developed to handle _BinMapper fields."""
+
+    def serialize(self, data, key, model_type):
+        """
+        Serialize _BinMapper values[usefull in HistGradientBoosting(Regressor,Classifier)].
+
+        serialize the data[key] of the given model which type is model_type.
+        basically in order to fully serialize a model, we should traverse over all the keys of its data dictionary and
+        pass it through the chain of associated transporters to get fully serialized.
+
+        :param data: the internal data dictionary of the given model
+        :type data: dict
+        :param key: the special key of the data param, which we're going to serialize its value(data[key])
+        :type key: object
+        :param model_type: the model type of the ML model, which data dictionary is given as the data param
+        :type model_type: str
+        :return: pymilo serialized output of data[key]
+        """
+        if isinstance(data[key], _BinMapper):
+            binMapper = data[key]
+            _data = binMapper.__dict__
+            gdst = GeneralDataStructureTransporter()
+            for _key in _data:
+                _data[_key] = gdst.serialize(_data, _key, model_type + ":_BinMapper")
+            return {
+                "pymilo-bypass": True,
+                "pymilo-binmapper": {
+                    "__dict__": _data
+                }
+            }
+        return data[key]
+
+    def deserialize(self, data, key, model_type):
+        """
+        Deserialize previously pymilo serialized _BinMapper objects[usefull in HistGradientBoosting(Regressor,Classifier)].
+
+        deserialize the data[key] of the given model which type is model_type.
+        basically in order to fully deserialize a model, we should traverse over all the keys of its serialized data dictionary and
+        pass it through the chain of associated transporters to get fully deserialized.
+
+        :param data: the internal data dictionary of the associated json file of the ML model which is generated previously by
+        pymilo export.
+        :type data: dict
+        :param key: the special key of the data param, which we're going to deserialize its value(data[key])
+        :type key: object
+        :param model_type: the model type of the ML model, which internal serialized data dictionary is given as the data param
+        :type model_type: str
+        :return: pymilo deserialized output of data[key]
+        """
+        content = data[key]
+        if is_primitive(content) or isinstance(content, type(None)):
+            return content
+        
+        if check_str_in_iterable("pymilo-binmapper", content):
+            __dict__ = content["pymilo-binmapper"]["__dict__"]
+            binMapper = _BinMapper()
+            gdst = GeneralDataStructureTransporter()
+            for key in __dict__:
+                __dict__[key] = gdst.deserialize(__dict__, key, model_type + ":_BinMapper")
+            for key in __dict__:
+                setattr(binMapper, key, __dict__[key])
+            return binMapper
+        
+        return content

--- a/pymilo/transporters/binmapper_transporter.py
+++ b/pymilo/transporters/binmapper_transporter.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""PyMilo Loss function transporter."""
+"""PyMilo BinMapper transporter."""
 from sklearn.ensemble._hist_gradient_boosting.binning import _BinMapper
 from ..utils.util import is_primitive, check_str_in_iterable
 from .transporter import AbstractTransporter
@@ -11,7 +11,7 @@ class BinMapperTransporter(AbstractTransporter):
 
     def serialize(self, data, key, model_type):
         """
-        Serialize _BinMapper values[usefull in HistGradientBoosting(Regressor,Classifier)].
+        Serialize _BinMapper object[usefull in HistGradientBoosting(Regressor,Classifier)].
 
         serialize the data[key] of the given model which type is model_type.
         basically in order to fully serialize a model, we should traverse over all the keys of its data dictionary and
@@ -41,7 +41,7 @@ class BinMapperTransporter(AbstractTransporter):
 
     def deserialize(self, data, key, model_type):
         """
-        Deserialize previously pymilo serialized _BinMapper objects[usefull in HistGradientBoosting(Regressor,Classifier)].
+        Deserialize previously pymilo serialized _BinMapper object[usefull in HistGradientBoosting(Regressor,Classifier)].
 
         deserialize the data[key] of the given model which type is model_type.
         basically in order to fully deserialize a model, we should traverse over all the keys of its serialized data dictionary and

--- a/pymilo/transporters/binmapper_transporter.py
+++ b/pymilo/transporters/binmapper_transporter.py
@@ -59,7 +59,7 @@ class BinMapperTransporter(AbstractTransporter):
         content = data[key]
         if is_primitive(content) or isinstance(content, type(None)):
             return content
-        
+
         if check_str_in_iterable("pymilo-binmapper", content):
             __dict__ = content["pymilo-binmapper"]["__dict__"]
             binMapper = _BinMapper()
@@ -69,5 +69,5 @@ class BinMapperTransporter(AbstractTransporter):
             for key in __dict__:
                 setattr(binMapper, key, __dict__[key])
             return binMapper
-        
+
         return content

--- a/pymilo/transporters/binmapper_transporter.py
+++ b/pymilo/transporters/binmapper_transporter.py
@@ -7,7 +7,7 @@ from .general_data_structure_transporter import GeneralDataStructureTransporter
 
 
 class BinMapperTransporter(AbstractTransporter):
-    """Customized PyMilo Transporter developed to handle _BinMapper fields."""
+    """Customized PyMilo Transporter developed to handle _BinMapper objects."""
 
     def serialize(self, data, key, model_type):
         """

--- a/pymilo/transporters/binmapper_transporter.py
+++ b/pymilo/transporters/binmapper_transporter.py
@@ -57,7 +57,7 @@ class BinMapperTransporter(AbstractTransporter):
         :return: pymilo deserialized output of data[key]
         """
         content = data[key]
-        if is_primitive(content) or isinstance(content, type(None)):
+        if is_primitive(content) or content is None:
             return content
 
         if check_str_in_iterable("pymilo-binmapper", content):

--- a/pymilo/transporters/bunch_transporter.py
+++ b/pymilo/transporters/bunch_transporter.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+"""PyMilo Bunch transporter."""
+from sklearn.utils._bunch import Bunch
+from .transporter import AbstractTransporter
+from ..utils.util import check_str_in_iterable
+
+class BunchTransporter(AbstractTransporter):
+    """Customized PyMilo Transporter developed to handle Bunch objects."""
+
+    def serialize(self, data, key, model_type):
+        """
+        Serialize Bunch object.
+
+        :param data: the internal data dictionary of the given model
+        :type data: dict
+        :param key: the special key of the data param, which we're going to serialize its value(data[key])
+        :type key: object
+        :param model_type: the model type of the ML model
+        :type model_type: str
+        :return: pymilo serialized output of data[key]
+        """
+        if isinstance(data[key], Bunch):
+            bunch = data[key]
+            dicted_bunch = {}
+            dicted_bunch["pymiloed-data-structure"] = "Bunch"
+            _dict = {}
+            for key, value in bunch.items():
+                _dict[key] = value
+            dicted_bunch["pymiloed-data"] = _dict 
+            return dicted_bunch
+        
+        return data[key]
+
+    def deserialize(self, data, key, model_type):
+        """
+        Deserialize previously pymilo serialized Bunch object.
+        
+        deserialize the data[key] of the given model which type is model_type.
+        basically in order to fully deserialize a model, we should traverse over all the keys of its serialized data dictionary and
+        pass it through the chain of associated transporters to get fully deserialized.
+
+        :param data: the internal data dictionary of the associated json file of the ML model which is generated previously by
+        pymilo export.
+        :type data: dict
+        :param key: the special key of the data param, which we're going to deserialize its value(data[key])
+        :type key: object
+        :param model_type: the model type of the ML model
+        :type model_type: str
+        :return: pymilo deserialized output of data[key]
+        """
+        content = data[key]
+        if check_str_in_iterable("pymiloed-data-structure", content) and content["pymiloed-data-structure"] == "Bunch":
+            bunch = Bunch()
+            dicted_bunch = content["pymiloed-data"]
+            for key, value in dicted_bunch.items():
+                bunch[key] = value
+            return bunch 
+        else:
+            return content

--- a/pymilo/transporters/bunch_transporter.py
+++ b/pymilo/transporters/bunch_transporter.py
@@ -4,6 +4,7 @@ from sklearn.utils._bunch import Bunch
 from .transporter import AbstractTransporter
 from ..utils.util import check_str_in_iterable
 
+
 class BunchTransporter(AbstractTransporter):
     """Customized PyMilo Transporter developed to handle Bunch objects."""
 
@@ -26,15 +27,15 @@ class BunchTransporter(AbstractTransporter):
             _dict = {}
             for key, value in bunch.items():
                 _dict[key] = value
-            dicted_bunch["pymiloed-data"] = _dict 
+            dicted_bunch["pymiloed-data"] = _dict
             return dicted_bunch
-        
+
         return data[key]
 
     def deserialize(self, data, key, model_type):
         """
         Deserialize previously pymilo serialized Bunch object.
-        
+
         deserialize the data[key] of the given model which type is model_type.
         basically in order to fully deserialize a model, we should traverse over all the keys of its serialized data dictionary and
         pass it through the chain of associated transporters to get fully deserialized.
@@ -54,6 +55,6 @@ class BunchTransporter(AbstractTransporter):
             dicted_bunch = content["pymiloed-data"]
             for key, value in dicted_bunch.items():
                 bunch[key] = value
-            return bunch 
+            return bunch
         else:
             return content

--- a/pymilo/transporters/generator_transporter.py
+++ b/pymilo/transporters/generator_transporter.py
@@ -53,7 +53,7 @@ class GeneratorTransporter(AbstractTransporter):
         :return: pymilo deserialized output of data[key]
         """
         content = data[key]
-        if is_primitive(content) or isinstance(content, type(None)):
+        if is_primitive(content) or content is None:
             return content
 
         if check_str_in_iterable("pymilo-generator", content):

--- a/pymilo/transporters/generator_transporter.py
+++ b/pymilo/transporters/generator_transporter.py
@@ -5,6 +5,7 @@ from ..utils.util import is_primitive, check_str_in_iterable
 from .transporter import AbstractTransporter
 from numpy.random import default_rng
 
+
 class GeneratorTransporter(AbstractTransporter):
     """Customized PyMilo Transporter developed to handle Generator objects."""
 
@@ -54,11 +55,11 @@ class GeneratorTransporter(AbstractTransporter):
         content = data[key]
         if is_primitive(content) or isinstance(content, type(None)):
             return content
-        
+
         if check_str_in_iterable("pymilo-generator", content):
             serialized_generator = content["pymilo-generator"]
             generator = default_rng(0)
             generator.__setstate__(serialized_generator["state"])
             return generator
-        
+
         return content

--- a/pymilo/transporters/generator_transporter.py
+++ b/pymilo/transporters/generator_transporter.py
@@ -7,10 +7,11 @@ from numpy.random import default_rng
 
 class GeneratorTransporter(AbstractTransporter):
     """Customized PyMilo Transporter developed to handle Generator objects."""
+
     def serialize(self, data, key, model_type):
         """
         Serialize Generator object.
-        
+
         serialize the data[key] of the given model which type is model_type.
         basically in order to fully serialize a model, we should traverse over all the keys of its data dictionary and
         pass it through the chain of associated transporters to get fully serialized.

--- a/pymilo/transporters/generator_transporter.py
+++ b/pymilo/transporters/generator_transporter.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""PyMilo Loss function transporter."""
+"""PyMilo Generator transporter."""
 from numpy.random._generator import Generator
 from ..utils.util import is_primitive, check_str_in_iterable
 from .transporter import AbstractTransporter
@@ -9,7 +9,7 @@ class GeneratorTransporter(AbstractTransporter):
     """Customized PyMilo Transporter developed to handle Generator objects."""
     def serialize(self, data, key, model_type):
         """
-        Serialize Generator values.
+        Serialize Generator object.
         
         serialize the data[key] of the given model which type is model_type.
         basically in order to fully serialize a model, we should traverse over all the keys of its data dictionary and
@@ -35,7 +35,7 @@ class GeneratorTransporter(AbstractTransporter):
 
     def deserialize(self, data, key, model_type):
         """
-        Deserialize previously pymilo serialized Generator objects.
+        Deserialize previously pymilo serialized Generator object.
 
         deserialize the data[key] of the given model which type is model_type.
         basically in order to fully deserialize a model, we should traverse over all the keys of its serialized data dictionary and

--- a/pymilo/transporters/generator_transporter.py
+++ b/pymilo/transporters/generator_transporter.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""PyMilo Loss function transporter."""
+from numpy.random._generator import Generator
+from ..utils.util import is_primitive, check_str_in_iterable
+from .transporter import AbstractTransporter
+from numpy.random import default_rng
+
+class GeneratorTransporter(AbstractTransporter):
+    """Customized PyMilo Transporter developed to handle Generator objects."""
+    def serialize(self, data, key, model_type):
+        """
+        Serialize Generator values.
+        
+        serialize the data[key] of the given model which type is model_type.
+        basically in order to fully serialize a model, we should traverse over all the keys of its data dictionary and
+        pass it through the chain of associated transporters to get fully serialized.
+
+        :param data: the internal data dictionary of the given model
+        :type data: dict
+        :param key: the special key of the data param, which we're going to serialize its value(data[key])
+        :type key: object
+        :param model_type: the model type of the ML model, which data dictionary is given as the data param
+        :type model_type: str
+        :return: pymilo serialized output of data[key]
+        """
+        if isinstance(data[key], Generator):
+            generator = data[key]
+            data[key] = {
+                "pymilo-bypass": True,
+                "pymilo-generator": {
+                    "state": generator.__getstate__()
+                }
+            }
+        return data[key]
+
+    def deserialize(self, data, key, model_type):
+        """
+        Deserialize previously pymilo serialized Generator objects.
+
+        deserialize the data[key] of the given model which type is model_type.
+        basically in order to fully deserialize a model, we should traverse over all the keys of its serialized data dictionary and
+        pass it through the chain of associated transporters to get fully deserialized.
+
+        :param data: the internal data dictionary of the associated json file of the ML model which is generated previously by
+        pymilo export.
+        :type data: dict
+        :param key: the special key of the data param, which we're going to deserialize its value(data[key])
+        :type key: object
+        :param model_type: the model type of the ML model, which internal serialized data dictionary is given as the data param
+        :type model_type: str
+        :return: pymilo deserialized output of data[key]
+        """
+        content = data[key]
+        if is_primitive(content) or isinstance(content, type(None)):
+            return content
+        
+        if check_str_in_iterable("pymilo-generator", content):
+            serialized_generator = content["pymilo-generator"]
+            generator = default_rng(0)
+            generator.__setstate__(serialized_generator["state"])
+            return generator
+        
+        return content

--- a/pymilo/transporters/labelencoder_transporter.py
+++ b/pymilo/transporters/labelencoder_transporter.py
@@ -51,7 +51,7 @@ class LabelEncoderTransporter(AbstractTransporter):
         :return: pymilo deserialized output of data[key]
         """
         content = data[key]
-        if is_primitive(content) or isinstance(content, type(None)):
+        if is_primitive(content) or content is None:
             return content
 
         if check_str_in_iterable("pymilo-labelencoder", content):

--- a/pymilo/transporters/labelencoder_transporter.py
+++ b/pymilo/transporters/labelencoder_transporter.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""PyMilo LabelEncoder transporter."""
+from sklearn.preprocessing import LabelEncoder
+from ..utils.util import is_primitive, check_str_in_iterable
+from .transporter import AbstractTransporter
+from .general_data_structure_transporter import GeneralDataStructureTransporter
+
+
+class LabelEncoderTransporter(AbstractTransporter):
+    """Customized PyMilo Transporter developed to LabelEncoder objects."""
+
+    def serialize(self, data, key, model_type):
+        """
+        Serialize LabelEncoder object.
+
+        serialize the data[key] of the given model which type is model_type.
+        basically in order to fully serialize a model, we should traverse over all the keys of its data dictionary and
+        pass it through the chain of associated transporters to get fully serialized.
+
+        :param data: the internal data dictionary of the given model
+        :type data: dict
+        :param key: the special key of the data param, which we're going to serialize its value(data[key])
+        :type key: object
+        :param model_type: the model type of the ML model, which data dictionary is given as the data param
+        :type model_type: str
+        :return: pymilo serialized output of data[key]
+        """
+        if isinstance(data[key], LabelEncoder):
+            label_encoder = data[key]
+            data[key] = {
+                "pymilo-bypass": True,
+                "pymilo-labelencoder": {
+                    "classes_": GeneralDataStructureTransporter().deep_serialize_ndarray(label_encoder.__dict__["classes_"])
+                }
+            }
+        return data[key]
+
+    def deserialize(self, data, key, model_type):
+        """
+        Deserialize previously pymilo serialized LabelEncoder object.
+
+        the associated loss_function_ field of the pymilo serialized model, is extracted through
+        the SGDClassifier's _get_loss_function function with enough feeding of the needed inputs.
+
+        deserialize the data[key] of the given model which type is model_type.
+        basically in order to fully deserialize a model, we should traverse over all the keys of its serialized data dictionary and
+        pass it through the chain of associated transporters to get fully deserialized.
+
+        :param data: the internal data dictionary of the associated json file of the ML model which is generated previously by
+        pymilo export.
+        :type data: dict
+        :param key: the special key of the data param, which we're going to deserialize its value(data[key])
+        :type key: object
+        :param model_type: the model type of the ML model, which internal serialized data dictionary is given as the data param
+        :type model_type: str
+        :return: pymilo deserialized output of data[key]
+        """
+        content = data[key]
+        if is_primitive(content) or isinstance(content, type(None)):
+            return content
+        
+        if check_str_in_iterable("pymilo-labelencoder", content):
+            serialized_le = content["pymilo-labelencoder"]
+            label_encoder = LabelEncoder()
+            setattr(label_encoder, "classes_", GeneralDataStructureTransporter().deep_deserialize_ndarray(serialized_le["classes_"]))
+            return label_encoder
+        
+        return content

--- a/pymilo/transporters/labelencoder_transporter.py
+++ b/pymilo/transporters/labelencoder_transporter.py
@@ -39,9 +39,6 @@ class LabelEncoderTransporter(AbstractTransporter):
         """
         Deserialize previously pymilo serialized LabelEncoder object.
 
-        the associated loss_function_ field of the pymilo serialized model, is extracted through
-        the SGDClassifier's _get_loss_function function with enough feeding of the needed inputs.
-
         deserialize the data[key] of the given model which type is model_type.
         basically in order to fully deserialize a model, we should traverse over all the keys of its serialized data dictionary and
         pass it through the chain of associated transporters to get fully deserialized.

--- a/pymilo/transporters/labelencoder_transporter.py
+++ b/pymilo/transporters/labelencoder_transporter.py
@@ -28,11 +28,9 @@ class LabelEncoderTransporter(AbstractTransporter):
         if isinstance(data[key], LabelEncoder):
             label_encoder = data[key]
             data[key] = {
-                "pymilo-bypass": True,
-                "pymilo-labelencoder": {
-                    "classes_": GeneralDataStructureTransporter().deep_serialize_ndarray(label_encoder.__dict__["classes_"])
-                }
-            }
+                "pymilo-bypass": True, "pymilo-labelencoder": {
+                    "classes_": GeneralDataStructureTransporter().deep_serialize_ndarray(
+                        label_encoder.__dict__["classes_"])}}
         return data[key]
 
     def deserialize(self, data, key, model_type):
@@ -55,11 +53,15 @@ class LabelEncoderTransporter(AbstractTransporter):
         content = data[key]
         if is_primitive(content) or isinstance(content, type(None)):
             return content
-        
+
         if check_str_in_iterable("pymilo-labelencoder", content):
             serialized_le = content["pymilo-labelencoder"]
             label_encoder = LabelEncoder()
-            setattr(label_encoder, "classes_", GeneralDataStructureTransporter().deep_deserialize_ndarray(serialized_le["classes_"]))
+            setattr(
+                label_encoder,
+                "classes_",
+                GeneralDataStructureTransporter().deep_deserialize_ndarray(
+                    serialized_le["classes_"]))
             return label_encoder
-        
+
         return content

--- a/pymilo/transporters/onehotencoder_transporter.py
+++ b/pymilo/transporters/onehotencoder_transporter.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+"""PyMilo OneHotEncoder transporter."""
+from sklearn.preprocessing import OneHotEncoder
+from ..utils.util import is_primitive, check_str_in_iterable
+from .transporter import AbstractTransporter
+
+
+class OneHotEncoderTransporter(AbstractTransporter):
+    """Customized PyMilo Transporter developed to handle OneHotEncoder objects."""
+
+    def serialize(self, data, key, model_type):
+        """
+        Serialize OneHotEncoder object.
+
+        serialize the data[key] of the given model which type is model_type.
+        basically in order to fully serialize a model, we should traverse over all the keys of its data dictionary and
+        pass it through the chain of associated transporters to get fully serialized.
+
+        :param data: the internal data dictionary of the given model
+        :type data: dict
+        :param key: the special key of the data param, which we're going to serialize its value(data[key])
+        :type key: object
+        :param model_type: the model type of the ML model, which data dictionary is given as the data param
+        :type model_type: str
+        :return: pymilo serialized output of data[key]
+        """
+        if isinstance(data[key], OneHotEncoder):
+            data[key] = {
+                "pymilo-onehotencoder": {
+                    "sparse_output": data["sparse_output"]
+                }
+            }
+        return data[key]
+
+    def deserialize(self, data, key, model_type):
+        """
+        Deserialize previously pymilo serialized OneHotEncoder object.
+
+        deserialize the data[key] of the given model which type is model_type.
+        basically in order to fully deserialize a model, we should traverse over all the keys of its serialized data dictionary and
+        pass it through the chain of associated transporters to get fully deserialized.
+
+        :param data: the internal data dictionary of the associated json file of the ML model which is generated previously by
+        pymilo export.
+        :type data: dict
+        :param key: the special key of the data param, which we're going to deserialize its value(data[key])
+        :type key: object
+        :param model_type: the model type of the ML model, which internal serialized data dictionary is given as the data param
+        :type model_type: str
+        :return: pymilo deserialized output of data[key]
+        """
+        content = data[key]
+        if is_primitive(content) or isinstance(content, type(None)):
+            return content
+        
+        if check_str_in_iterable("pymilo-onehotencoder", content):
+            return OneHotEncoder(sparse_output=content["pymilo-onehotencoder"]["sparse_output"])
+        return content

--- a/pymilo/transporters/onehotencoder_transporter.py
+++ b/pymilo/transporters/onehotencoder_transporter.py
@@ -50,7 +50,7 @@ class OneHotEncoderTransporter(AbstractTransporter):
         :return: pymilo deserialized output of data[key]
         """
         content = data[key]
-        if is_primitive(content) or isinstance(content, type(None)):
+        if is_primitive(content) or content is None:
             return content
 
         if check_str_in_iterable("pymilo-onehotencoder", content):

--- a/pymilo/transporters/onehotencoder_transporter.py
+++ b/pymilo/transporters/onehotencoder_transporter.py
@@ -52,7 +52,7 @@ class OneHotEncoderTransporter(AbstractTransporter):
         content = data[key]
         if is_primitive(content) or isinstance(content, type(None)):
             return content
-        
+
         if check_str_in_iterable("pymilo-onehotencoder", content):
             return OneHotEncoder(sparse_output=content["pymilo-onehotencoder"]["sparse_output"])
         return content

--- a/pymilo/transporters/treepredictor_transporter.py
+++ b/pymilo/transporters/treepredictor_transporter.py
@@ -24,7 +24,6 @@ class TreePredictorTransporter(AbstractTransporter):
         :type model_type: str
         :return: pymilo serialized output of data[key]
         """
-
         if isinstance(data[key], TreePredictor):
             return self.serialize_tree_predictor(data[key], model_type)
         elif isinstance(data[key], list):

--- a/pymilo/transporters/treepredictor_transporter.py
+++ b/pymilo/transporters/treepredictor_transporter.py
@@ -26,7 +26,7 @@ class TreePredictorTransporter(AbstractTransporter):
         :return: pymilo serialized output of data[key]
         """
         if isinstance(data[key], TreePredictor):
-            return self.serialize_tree_predictor(data[key], model_type)
+            return self.serialize_tree_predictor(data[key])
         elif isinstance(data[key], list):
             return self.serialize_possible_inner_tree_predictor(data[key])
         return data[key]

--- a/pymilo/transporters/treepredictor_transporter.py
+++ b/pymilo/transporters/treepredictor_transporter.py
@@ -5,6 +5,7 @@ from ..utils.util import check_str_in_iterable
 from .transporter import AbstractTransporter
 from .general_data_structure_transporter import GeneralDataStructureTransporter
 
+
 class TreePredictorTransporter(AbstractTransporter):
     """Customized PyMilo Transporter developed to handle TreePredictor objects."""
 
@@ -74,7 +75,9 @@ class TreePredictorTransporter(AbstractTransporter):
 
         :return: bool
         """
-        return check_str_in_iterable("pymiloed-data-structure", serialized_treepredictor) and serialized_treepredictor["pymiloed-data-structure"] == "TreePredictor"
+        return check_str_in_iterable(
+            "pymiloed-data-structure",
+            serialized_treepredictor) and serialized_treepredictor["pymiloed-data-structure"] == "TreePredictor"
 
     def serialize_tree_predictor(self, treepredictor):
         """
@@ -115,14 +118,19 @@ class TreePredictorTransporter(AbstractTransporter):
         nodes = serialized_tree_predictor["pymiloed-data"]["nodes"]["pymiloed-ndarray-list"]
         for idx, value in enumerate(nodes):
             nodes[idx] = tuple(value)
-        
+
         binned_left_cat_bitsets = serialized_tree_predictor["pymiloed-data"]["binned_left_cat_bitsets"]
         raw_left_cat_bitsets = serialized_tree_predictor["pymiloed-data"]["raw_left_cat_bitsets"]
-        
+
         return TreePredictor(
-            nodes= gdst.deep_deserialize_ndarray(serialized_tree_predictor["pymiloed-data"]["nodes"]),
-            binned_left_cat_bitsets= gdst.deep_deserialize_ndarray(binned_left_cat_bitsets["content"]).reshape(binned_left_cat_bitsets["shape"]),
-            raw_left_cat_bitsets= gdst.deep_deserialize_ndarray(raw_left_cat_bitsets["content"]).reshape(raw_left_cat_bitsets["shape"]),
+            nodes=gdst.deep_deserialize_ndarray(
+                serialized_tree_predictor["pymiloed-data"]["nodes"]),
+            binned_left_cat_bitsets=gdst.deep_deserialize_ndarray(
+                binned_left_cat_bitsets["content"]).reshape(
+                binned_left_cat_bitsets["shape"]),
+            raw_left_cat_bitsets=gdst.deep_deserialize_ndarray(
+                raw_left_cat_bitsets["content"]).reshape(
+                raw_left_cat_bitsets["shape"]),
         )
 
     def serialize_possible_inner_tree_predictor(self, _list):

--- a/pymilo/transporters/treepredictor_transporter.py
+++ b/pymilo/transporters/treepredictor_transporter.py
@@ -105,7 +105,7 @@ class TreePredictorTransporter(AbstractTransporter):
 
     def deserialize_tree_predictor(self, serialized_tree_predictor):
         """
-        Deserialize to pure Treepredictor object
+        Deserialize to pure Treepredictor object.
 
         :param serialized_tree_predictor: pymilo-serialized treepredictor
         :type serialized_tree_predictor: dict

--- a/pymilo/transporters/treepredictor_transporter.py
+++ b/pymilo/transporters/treepredictor_transporter.py
@@ -1,0 +1,159 @@
+# -*- coding: utf-8 -*-
+"""PyMilo TreePredictor transporter."""
+from sklearn.ensemble._hist_gradient_boosting.predictor import TreePredictor
+from ..utils.util import check_str_in_iterable
+from .transporter import AbstractTransporter
+from .general_data_structure_transporter import GeneralDataStructureTransporter
+
+class TreePredictorTransporter(AbstractTransporter):
+    """Customized PyMilo Transporter developed to handle TreePredictor objects."""
+
+    def serialize(self, data, key, model_type):
+        """
+        Serialize TreePredictor object[usefull in HistGradientBoosting(Regressor,Classifier)].
+
+        serialize the data[key] of the given model which type is model_type.
+        basically in order to fully serialize a model, we should traverse over all the keys of its data dictionary and
+        pass it through the chain of associated transporters to get fully serialized.
+
+        :param data: the internal data dictionary of the given model
+        :type data: dict
+        :param key: the special key of the data param, which we're going to serialize its value(data[key])
+        :type key: object
+        :param model_type: the model type of the ML model, which data dictionary is given as the data param
+        :type model_type: str
+        :return: pymilo serialized output of data[key]
+        """
+
+        if isinstance(data[key], TreePredictor):
+            return self.serialize_tree_predictor(data[key], model_type)
+        elif isinstance(data[key], list):
+            return self.serialize_possible_inner_tree_predictor(data[key])
+        return data[key]
+
+    def deserialize(self, data, key, model_type):
+        """
+        Deserialize previously pymilo serialized TreePredictor object[usefull in HistGradientBoosting(Regressor,Classifier)].
+
+        deserialize the data[key] of the given model which type is model_type.
+        basically in order to fully deserialize a model, we should traverse over all the keys of its serialized data dictionary and
+        pass it through the chain of associated transporters to get fully deserialized.
+
+        :param data: the internal data dictionary of the associated json file of the ML model which is generated previously by
+        pymilo export.
+        :type data: dict
+        :param key: the special key of the data param, which we're going to deserialize its value(data[key])
+        :type key: object
+        :param model_type: the model type of the ML model, which internal serialized data dictionary is given as the data param
+        :type model_type: str
+        :return: pymilo deserialized output of data[key]
+        """
+        content = data[key]
+        if self.is_serialized_treepredictor(content):
+            return self.deserialize_tree_predictor(content)
+        if isinstance(content, list):
+            return self.deserialize_possible_inner_tree_predictor(content)
+        return content
+
+    def is_treepredictor(self, treepredictor):
+        """
+        Check if the given object is an instance of TreePredictor class.
+
+        :param treepredictor: given object to check
+        :type treepredictor: any
+
+        :return: bool
+        """
+        return isinstance(treepredictor, TreePredictor)
+
+    def is_serialized_treepredictor(self, serialized_treepredictor):
+        """
+        Check if the given object is a previously pymilo-serialized TreePredictor.
+
+        :param serialized_treepredictor: given object to check
+        :type serialized_treepredictor: any
+
+        :return: bool
+        """
+        return check_str_in_iterable("pymiloed-data-structure", serialized_treepredictor) and serialized_treepredictor["pymiloed-data-structure"] == "TreePredictor"
+
+    def serialize_tree_predictor(self, treepredictor):
+        """
+        Serialize given Treepredictor instance.
+
+        :param treepredictor: given treepredictor to get serialized
+        :type treepredictor: Treepredictor
+
+        :return: dict
+        """
+        gdst = GeneralDataStructureTransporter()
+        return {
+            "pymilo-bypass": True,
+            "pymiloed-data-structure": 'TreePredictor',
+            "pymiloed-data": {
+                "nodes": gdst.deep_serialize_ndarray(treepredictor.nodes),
+                "binned_left_cat_bitsets": {
+                    "content": gdst.deep_serialize_ndarray(treepredictor.binned_left_cat_bitsets),
+                    "shape": treepredictor.binned_left_cat_bitsets.shape
+                },
+                "raw_left_cat_bitsets": {
+                    "content": gdst.deep_serialize_ndarray(treepredictor.raw_left_cat_bitsets),
+                    "shape": treepredictor.raw_left_cat_bitsets.shape
+                },
+            },
+        }
+
+    def deserialize_tree_predictor(self, serialized_tree_predictor):
+        """
+        Deserialize to pure Treepredictor object
+
+        :param serialized_tree_predictor: pymilo-serialized treepredictor
+        :type serialized_tree_predictor: dict
+
+        :return: Treepredictor
+        """
+        gdst = GeneralDataStructureTransporter()
+        nodes = serialized_tree_predictor["pymiloed-data"]["nodes"]["pymiloed-ndarray-list"]
+        for idx, value in enumerate(nodes):
+            nodes[idx] = tuple(value)
+        
+        binned_left_cat_bitsets = serialized_tree_predictor["pymiloed-data"]["binned_left_cat_bitsets"]
+        raw_left_cat_bitsets = serialized_tree_predictor["pymiloed-data"]["raw_left_cat_bitsets"]
+        
+        return TreePredictor(
+            nodes= gdst.deep_deserialize_ndarray(serialized_tree_predictor["pymiloed-data"]["nodes"]),
+            binned_left_cat_bitsets= gdst.deep_deserialize_ndarray(binned_left_cat_bitsets["content"]).reshape(binned_left_cat_bitsets["shape"]),
+            raw_left_cat_bitsets= gdst.deep_deserialize_ndarray(raw_left_cat_bitsets["content"]).reshape(raw_left_cat_bitsets["shape"]),
+        )
+
+    def serialize_possible_inner_tree_predictor(self, _list):
+        """
+        Traverse over list and serialize Treepredictor objects.
+
+        :param _list: given list to serialize inner Treepredictor objects
+        :type _list: list
+
+        :return: list
+        """
+        for idx, value in enumerate(_list):
+            if self.is_treepredictor(value):
+                _list[idx] = self.serialize_tree_predictor(value)
+            if isinstance(value, list):
+                _list[idx] = self.serialize_possible_inner_tree_predictor(value)
+        return _list
+
+    def deserialize_possible_inner_tree_predictor(self, _list):
+        """
+        Traverse over list and deserialize previously pymilo-serialized Treepredictor objects.
+
+        :param _list: given list to deserialize inner Treepredictor objects
+        :type _list: list
+
+        :return: list
+        """
+        for idx, value in enumerate(_list):
+            if self.is_serialized_treepredictor(value):
+                _list[idx] = self.deserialize_tree_predictor(value)
+            if isinstance(value, list):
+                _list[idx] = self.deserialize_possible_inner_tree_predictor(value)
+        return _list


### PR DESCRIPTION
#### Reference Issues/PRs
add new transporters to prepare ensemble model support

Ensemble dedicated transporters:
* BinMapper Transporter
* GeneratorTransporter
* BunchTransporter
* TreePredictorTransporter

Some models from the `preprocessing` module:
* LabelEncoder Transporter
* OneHotEncoder Transporter
#### What does this implement/fix? Explain your changes.

#### Any other comments?

