### PR TITLE
Fix/minor naming feedback

### DIFF
--- a/pymilo/streaming/__init__.py
+++ b/pymilo/streaming/__init__.py
@@ -1,2 +1,5 @@
 # -*- coding: utf-8 -*-
 """PyMilo ML Streaming."""
+from .pymilo_client import PymiloClient
+from .pymilo_server import PymiloServer
+from .compressor import Compression

--- a/pymilo/streaming/pymilo_server.py
+++ b/pymilo/streaming/pymilo_server.py
@@ -24,7 +24,7 @@ class PymiloServer:
         self._model = None
         self._compressor = compressor.value
         self._encryptor = DummyEncryptor()
-        self._communicator = RESTServerCommunicator(ps=self, port=port)
+        self.communicator = RESTServerCommunicator(ps=self, port=port)
 
     def export_model(self):
         """

--- a/tests/test_ml_streaming/run_server.py
+++ b/tests/test_ml_streaming/run_server.py
@@ -1,6 +1,6 @@
 import argparse
-from pymilo.streaming.compressor import Compression
-from pymilo.streaming.pymilo_server import PymiloServer
+from pymilo.streaming import Compression
+from pymilo.streaming import PymiloServer
 
 
 def main():
@@ -8,7 +8,7 @@ def main():
     parser.add_argument('--compression', type=str, choices=['NULL', 'GZIP', 'ZLIB', 'LZMA', 'BZ2'], default='NULL',
                         help='Specify the compression method (NULL, GZIP, ZLIB, LZMA, or BZ2). Default is NULL.')
     args = parser.parse_args()
-    communicator = PymiloServer(compressor=Compression[args.compression])._communicator
+    communicator = PymiloServer(compressor=Compression[args.compression]).communicator
     communicator.run()
 
 if __name__ == '__main__':

--- a/tests/test_ml_streaming/scenarios/scenario1.py
+++ b/tests/test_ml_streaming/scenarios/scenario1.py
@@ -1,8 +1,8 @@
 import numpy as np
+from pymilo.streaming import Compression
+from pymilo.streaming import PymiloClient
 from sklearn.metrics import mean_squared_error
 from sklearn.linear_model import LinearRegression
-from pymilo.streaming.compressor import Compression
-from pymilo.streaming.pymilo_client import PymiloClient, Mode
 from pymilo.utils.data_exporter import prepare_simple_regression_datasets
 
 
@@ -21,7 +21,7 @@ def scenario1(compression_method):
 
     # 2.
     linear_regression.fit(x_train, y_train)
-    client = PymiloClient(model=linear_regression, mode=Mode.LOCAL, compressor=Compression[compression_method])
+    client = PymiloClient(model=linear_regression, mode=PymiloClient.Mode.LOCAL, compressor=Compression[compression_method])
 
     # 3.
     result = client.predict(x_test)

--- a/tests/test_ml_streaming/scenarios/scenario2.py
+++ b/tests/test_ml_streaming/scenarios/scenario2.py
@@ -1,8 +1,8 @@
 import numpy as np
+from pymilo.streaming import Compression
+from pymilo.streaming import PymiloClient
 from sklearn.metrics import mean_squared_error
 from sklearn.linear_model import LinearRegression
-from pymilo.streaming.compressor import Compression
-from pymilo.streaming.pymilo_client import PymiloClient, Mode
 from pymilo.utils.data_exporter import prepare_simple_regression_datasets
 
 
@@ -18,13 +18,13 @@ def scenario2(compression_method):
     # 1.
     x_train, y_train, x_test, y_test = prepare_simple_regression_datasets()
     linear_regression = LinearRegression()
-    client = PymiloClient(model=linear_regression, mode=Mode.LOCAL, compressor=Compression[compression_method])
+    client = PymiloClient(model=linear_regression, mode=PymiloClient.Mode.LOCAL, compressor=Compression[compression_method])
 
     # 2.
     client.upload()
 
     # 3.
-    client.toggle_mode(Mode.DELEGATE)
+    client.toggle_mode(PymiloClient.Mode.DELEGATE)
     client.fit(x_train, y_train)
     remote_field = client.coef_
 
@@ -36,7 +36,7 @@ def scenario2(compression_method):
     client.download()
 
     # 6.
-    client.toggle_mode(mode=Mode.LOCAL)
+    client.toggle_mode(mode=PymiloClient.Mode.LOCAL)
     local_field = client.coef_
     result = client.predict(x_test)
     mse_local = mean_squared_error(y_test, result)


### PR DESCRIPTION
#### Reference Issues/PRs

- ability to import main streaming modules directly from streaming folder
- refactor naming convention and remove `_` from the beginning of non-private field attributes
- refactor `Mode` enum to be an inner class of `PyMiloClient` class
#### What does this implement/fix? Explain your changes.

#### Any other comments?

