### PR TITLE
split tests & skip win py 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ on:
 env:
   TEST_PYTHON_VERSION: 3.9
   TEST_OS: 'ubuntu-20.04'
+  SKIP_STREAMING_OS: 'windows-2022'
+  SKIP_STREAMING_PYTHON_VERSION: 3.11
 
 jobs:
   build:
@@ -40,12 +42,21 @@ jobs:
         run: |
           python otherfiles/requirements-splitter.py
           pip install --upgrade --upgrade-strategy=only-if-needed -r test-requirements.txt
-      - name: Pymilo Functionality Tests with pytest 
+      - name: Pymilo Core Functionality Tests with pytest
         run: |
-          python -m pytest . --cov=pymilo --cov-report=term
+          python -m pytest . --ignore=./tests/test_ml_streaming --cov=pymilo --cov-report=term --cov-report=xml:coverage_core.xml
+      - name: Pymilo Streaming Functionality Tests with pytest
+        run: |
+          python -m pytest ./tests/test_ml_streaming --cov=pymilo --cov-report=term --cov-report=xml:coverage_streaming.xml
+        if: matrix.python-version == env.SKIP_STREAMING_PYTHON_VERSION && matrix.os == env.SKIP_STREAMING_OS
+      - name: Merge coverage files
+        run: |
+          coverage combine
+          coverage xml -o coverage_combined.xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
+            files: coverage_combined.xml
             fail_ci_if_error: false
         if: matrix.python-version == env.TEST_PYTHON_VERSION && matrix.os == env.TEST_OS
       - name: Vulture, Bandit and Pydocstyle Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,6 @@ jobs:
         if: matrix.python-version != env.SKIP_STREAMING_PYTHON_VERSION || matrix.os != env.SKIP_STREAMING_OS
       - name: Merge coverage files
         run: |
-          ls -a
           coverage combine
           coverage xml -o coverage_combined.xml
       - name: Upload coverage to Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
           COVERAGE_FILE: .coverage.streaming
         run: |
           python -m pytest ./tests/test_ml_streaming --cov=pymilo --cov-report=term --cov-report=xml:coverage_streaming.xml
-        if: matrix.python-version != env.SKIP_STREAMING_PYTHON_VERSION && matrix.os != env.SKIP_STREAMING_OS
+        if: matrix.python-version != env.SKIP_STREAMING_PYTHON_VERSION || matrix.os != env.SKIP_STREAMING_OS
       - name: Merge coverage files
         run: |
           ls -a

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ env:
   TEST_PYTHON_VERSION: 3.9
   TEST_OS: 'ubuntu-20.04'
   SKIP_STREAMING_OS: 'windows-2022'
-  SKIP_STREAMING_PYTHON_VERSION: 3.11
+  SKIP_STREAMING_PYTHON_VERSION: 3.11.0
 
 jobs:
   build:
@@ -48,7 +48,7 @@ jobs:
       - name: Pymilo Streaming Functionality Tests with pytest
         run: |
           python -m pytest ./tests/test_ml_streaming --cov=pymilo --cov-report=term --cov-report=xml:coverage_streaming.xml
-        if: matrix.python-version == env.SKIP_STREAMING_PYTHON_VERSION && matrix.os == env.SKIP_STREAMING_OS
+        if: matrix.python-version != env.SKIP_STREAMING_PYTHON_VERSION && matrix.os != env.SKIP_STREAMING_OS
       - name: Merge coverage files
         run: |
           coverage combine

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,7 @@ jobs:
         if: matrix.python-version != env.SKIP_STREAMING_PYTHON_VERSION && matrix.os != env.SKIP_STREAMING_OS
       - name: Merge coverage files
         run: |
+          ls -a
           coverage combine
           coverage xml -o coverage_combined.xml
       - name: Upload coverage to Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,9 +43,13 @@ jobs:
           python otherfiles/requirements-splitter.py
           pip install --upgrade --upgrade-strategy=only-if-needed -r test-requirements.txt
       - name: Pymilo Core Functionality Tests with pytest
+        env:
+          COVERAGE_FILE: .coverage.core
         run: |
           python -m pytest . --ignore=./tests/test_ml_streaming --cov=pymilo --cov-report=term --cov-report=xml:coverage_core.xml
       - name: Pymilo Streaming Functionality Tests with pytest
+        env:
+          COVERAGE_FILE: .coverage.streaming
         run: |
           python -m pytest ./tests/test_ml_streaming --cov=pymilo --cov-report=term --cov-report=xml:coverage_streaming.xml
         if: matrix.python-version != env.SKIP_STREAMING_PYTHON_VERSION && matrix.os != env.SKIP_STREAMING_OS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - PyMilo exception types added in `pymilo/exceptions/__init__.py`
 - PyMilo exception types added in `pymilo/__init__.py`
 ### Changed
+- `core` and `streaming` tests divided in `test.yml`
 - `communication_protocol` parameter added to `PyMiloClient` class
 - `communication_protocol` parameter added to `PyMiloServer` class
 - `ML Streaming` testcases updated to support protocol selection


### PR DESCRIPTION
#### Reference Issues/PRs
- split core and streaming tests
- do not run streaming test on win + python 3.11 until we fix it finally
- combine core and streaming coverage
#### What does this implement/fix? Explain your changes.

#### Any other comments?

