### PR TITLE
WebSocket streaming alignment & deprecation fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `scenario4` access control test for streaming
 - `--port` argument in test server runner
 - `close` function in `WebSocketClientCommunicator`
+- `close` function in `PymiloClient`
+- Context manager support (`__enter__`/`__exit__`) in `PymiloClient`
 ### Changed
 - `_ArrayFunctionDispatcher` import in `FunctionTransporter` to use new numpy API
 - `datetime.utcnow()` to `datetime.now(timezone.utc)` in `PymiloException`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `_handle_get_allowed_models` function in `WebSocketServerCommunicator`
 - `scenario4` access control test for streaming
 - `--port` argument in test server runner
+- `close` function in `WebSocketClientCommunicator`
 ### Changed
+- `_ArrayFunctionDispatcher` import in `FunctionTransporter` to use new numpy API
+- `datetime.utcnow()` to `datetime.now(timezone.utc)` in `PymiloException`
 - `get_allowance` endpoint in `RESTServerCommunicator` to handle empty allowances
 - `send_message` function in `WebSocketClientCommunicator`
 - `download` function in `WebSocketClientCommunicator`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `_check_response_error` function in `WebSocketClientCommunicator`
+- `register_client` function in `WebSocketClientCommunicator`
+- `remove_client` function in `WebSocketClientCommunicator`
+- `register_model` function in `WebSocketClientCommunicator`
+- `remove_model` function in `WebSocketClientCommunicator`
+- `get_ml_models` function in `WebSocketClientCommunicator`
+- `grant_access` function in `WebSocketClientCommunicator`
+- `revoke_access` function in `WebSocketClientCommunicator`
+- `get_allowance` function in `WebSocketClientCommunicator`
+- `get_allowed_models` function in `WebSocketClientCommunicator`
+- `_action_handlers` registry in `WebSocketServerCommunicator`
+- `_handle_register_client` function in `WebSocketServerCommunicator`
+- `_handle_remove_client` function in `WebSocketServerCommunicator`
+- `_handle_register_model` function in `WebSocketServerCommunicator`
+- `_handle_remove_model` function in `WebSocketServerCommunicator`
+- `_handle_get_ml_models` function in `WebSocketServerCommunicator`
+- `_handle_grant_access` function in `WebSocketServerCommunicator`
+- `_handle_revoke_access` function in `WebSocketServerCommunicator`
+- `_handle_get_allowance` function in `WebSocketServerCommunicator`
+- `_handle_get_allowed_models` function in `WebSocketServerCommunicator`
+- `scenario4` access control test for streaming
+- `--port` argument in test server runner
+### Changed
+- `get_allowance` endpoint in `RESTServerCommunicator` to handle empty allowances
+- `send_message` function in `WebSocketClientCommunicator`
+- `download` function in `WebSocketClientCommunicator`
+- `upload` function in `WebSocketClientCommunicator`
+- `attribute_call` function in `WebSocketClientCommunicator`
+- `attribute_type` function in `WebSocketClientCommunicator`
+- `__init__` function in `WebSocketServerCommunicator`
+- `handle_message` function in `WebSocketServerCommunicator`
+- `_handle_download` function in `WebSocketServerCommunicator`
+- `_handle_upload` function in `WebSocketServerCommunicator`
+- `_handle_attribute_call` function in `WebSocketServerCommunicator`
+- `_handle_attribute_type` function in `WebSocketServerCommunicator`
+- `parse` function in `WebSocketServerCommunicator`
+- WebSocket streaming tests enabled
 ## [1.5] - 2026-01-26
 ### Added
 - `_is_remainder_cols_list` function in GeneralDataStructureTransporter

--- a/pymilo/exceptions/pymilo_exception.py
+++ b/pymilo/exceptions/pymilo_exception.py
@@ -4,7 +4,7 @@
 import pymilo
 import sklearn
 import platform
-from datetime import datetime
+from datetime import datetime, timezone
 from abc import ABC, abstractmethod
 
 
@@ -50,7 +50,7 @@ class PymiloException(Exception, ABC):
                 'content': self.meta_data['object']
             },
             'error': {
-                'date-utc': datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S'),
+                'date-utc': datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S'),
                 'pymilo-error': self.message,
                 'inner-error': self.meta_data['error'] if "error" in self.meta_data else ""
             }

--- a/pymilo/streaming/communicator.py
+++ b/pymilo/streaming/communicator.py
@@ -291,7 +291,7 @@ class RESTServerCommunicator():
         @self.app.get(f"{REST_API_PREFIX}/clients/{{allower_id}}/allowances")
         async def get_allowance(allower_id: str):
             allowance, reason = self._ps.get_clients_allowance(allower_id)
-            if not allowance:
+            if allowance is None:
                 raise HTTPException(status_code=404, detail=reason)
             return {"allower_id": allower_id, "allowance": allowance}
 
@@ -390,8 +390,7 @@ class WebSocketClientCommunicator(ClientCommunicator):
             raise Exception(PYMILO_INVALID_URL)
         self.server_url = url
         self.websocket = None
-        self.connection_established = asyncio.Event()  # Event to signal connection status
-        # check for even loop existance
+        self.connection_established = asyncio.Event()
         if asyncio._get_running_loop() is None:
             self.loop = asyncio.new_event_loop()
             asyncio.set_event_loop(self.loop)
@@ -407,9 +406,9 @@ class WebSocketClientCommunicator(ClientCommunicator):
         """
         if self.websocket is None:
             return True
-        elif hasattr(self.websocket, "closed"):  # For older versions
+        elif hasattr(self.websocket, "closed"):
             return self.websocket.closed
-        elif hasattr(self.websocket, "state"):  # For newer versions
+        elif hasattr(self.websocket, "state"):
             return self.websocket.state is websockets.protocol.State.CLOSED
 
     async def connect(self):
@@ -424,7 +423,7 @@ class WebSocketClientCommunicator(ClientCommunicator):
         if self.websocket:
             await self.websocket.close()
 
-    async def send_message(self, action: str, payload: dict) -> dict:
+    async def send_message(self, action: str, payload: dict = None) -> dict:
         """
         Send a message to the WebSocket server.
 
@@ -439,62 +438,249 @@ class WebSocketClientCommunicator(ClientCommunicator):
         if self.is_socket_closed():
             raise RuntimeError(PYMILO_CLIENT_WEBSOCKET_NOT_CONNECTED)
 
-        message = json.dumps({"action": action, "payload": payload})
+        message = json.dumps({"action": action, "payload": payload or {}})
         await self.websocket.send(message)
         response = await self.websocket.recv()
         return json.loads(response)
 
-    def download(self, payload: dict) -> dict:
+    def _check_response_error(self, response: dict) -> None:
         """
-        Request the remote ML model to download.
+        Check if the server response contains an error and raise an exception if so.
 
-        :param payload: the payload for the download request.
-        :type payload: dict
-        :return: the downloaded model data.
+        :param response: the server's response.
+        :type response: dict
+        :return: None
+        :raises RuntimeError: if the response contains an error.
+        """
+        if "error" in response:
+            raise RuntimeError(response["error"])
+
+    def download(self, client_id, model_id):
+        """
+        Request for the remote ML model to download.
+
+        :param client_id: ID of the requesting client
+        :type client_id: str
+        :param model_id: ID of the model to download
+        :type model_id: str
+        :return: string serialized model
         """
         response = self.loop.run_until_complete(
-            self.send_message("download", payload)
+            self.send_message("download", {
+                "client_id": client_id,
+                "ml_model_id": model_id,
+            })
         )
+        self._check_response_error(response)
         return response.get("payload")
 
-    def upload(self, payload: dict) -> bool:
+    def upload(self, client_id, model_id, model):
         """
         Upload the local ML model to the remote server.
 
-        :param payload: the payload for the upload request.
-        :type payload: dict
-        :return: true if the upload request is acknowledged.
+        :param client_id: ID of the client
+        :type client_id: str
+        :param model_id: ID of the model
+        :type model_id: str
+        :param model: serialized model content
+        :return: True if upload was successful, False otherwise
         """
         response = self.loop.run_until_complete(
-            self.send_message("upload", payload)
+            self.send_message("upload", {
+                "client_id": client_id,
+                "ml_model_id": model_id,
+                "model": model,
+            })
         )
-        return response.get("message") == "Upload request received."
+        return "error" not in response
 
-    def attribute_call(self, payload: dict) -> dict:
+    def attribute_call(self, client_id, model_id, call_payload):
         """
         Delegate the requested attribute call to the remote server.
 
-        :param payload: the payload containing attribute call details.
-        :type payload: dict
-        :return: the server's response to the attribute call.
+        :param client_id: ID of the client
+        :type client_id: str
+        :param model_id: ID of the model
+        :type model_id: str
+        :param call_payload: payload containing attribute name, args, and kwargs
+        :return: json-encoded response of pymilo server
         """
         response = self.loop.run_until_complete(
-            self.send_message("attribute_call", payload)
+            self.send_message("attribute_call", {
+                "client_id": client_id,
+                "ml_model_id": model_id,
+                "call_payload": call_payload,
+            })
         )
+        self._check_response_error(response)
         return response
 
-    def attribute_type(self, payload: dict) -> dict:
+    def attribute_type(self, client_id, model_id, type_payload):
         """
         Identify the attribute type of the requested attribute.
 
-        :param payload: the payload containing attribute type request.
-        :type payload: dict
-        :return: the server's response with the attribute type.
+        :param client_id: ID of the client
+        :type client_id: str
+        :param model_id: ID of the model
+        :type model_id: str
+        :param type_payload: payload containing attribute data to inspect
+        :return: response of pymilo server
         """
         response = self.loop.run_until_complete(
-            self.send_message("attribute_type", payload)
+            self.send_message("attribute_type", {
+                "client_id": client_id,
+                "ml_model_id": model_id,
+                "type_payload": type_payload,
+            })
         )
+        self._check_response_error(response)
         return response
+
+    def register_client(self):
+        """
+        Register client in the PyMiloServer.
+
+        :return: newly allocated client id
+        """
+        response = self.loop.run_until_complete(
+            self.send_message("register_client")
+        )
+        self._check_response_error(response)
+        return response["client_id"]
+
+    def remove_client(self, client_id):
+        """
+        Remove client from the PyMiloServer.
+
+        :param client_id: id of the client to remove
+        :type client_id: str
+        :return: True if removal was successful, False otherwise
+        """
+        response = self.loop.run_until_complete(
+            self.send_message("remove_client", {"client_id": client_id})
+        )
+        return "error" not in response
+
+    def register_model(self, client_id):
+        """
+        Register ML model in the PyMiloServer.
+
+        :param client_id: id of the client who owns the model
+        :type client_id: str
+        :return: newly allocated ml model id
+        """
+        response = self.loop.run_until_complete(
+            self.send_message("register_model", {"client_id": client_id})
+        )
+        self._check_response_error(response)
+        return response["ml_model_id"]
+
+    def remove_model(self, client_id, model_id):
+        """
+        Remove ML model from the PyMiloServer.
+
+        :param client_id: client owning the model
+        :type client_id: str
+        :param model_id: model to remove
+        :type model_id: str
+        :return: True if removal was successful, False otherwise
+        """
+        response = self.loop.run_until_complete(
+            self.send_message("remove_model", {
+                "client_id": client_id,
+                "ml_model_id": model_id,
+            })
+        )
+        return "error" not in response
+
+    def get_ml_models(self, client_id):
+        """
+        Get all ML models registered for this specific client in the PyMiloServer.
+
+        :param client_id: client whose models are being queried
+        :type client_id: str
+        :return: list of ml model ids
+        """
+        response = self.loop.run_until_complete(
+            self.send_message("get_ml_models", {"client_id": client_id})
+        )
+        self._check_response_error(response)
+        return response["ml_models_id"]
+
+    def grant_access(self, allower_id, allowee_id, model_id):
+        """
+        Grant access to a model to another client.
+
+        :param allower_id: ID of the client granting access
+        :type allower_id: str
+        :param allowee_id: ID of the client being granted access
+        :type allowee_id: str
+        :param model_id: ID of the model being shared
+        :type model_id: str
+        :return: True if successful, False otherwise
+        """
+        response = self.loop.run_until_complete(
+            self.send_message("grant_access", {
+                "allower_id": allower_id,
+                "allowee_id": allowee_id,
+                "model_id": model_id,
+            })
+        )
+        return "error" not in response
+
+    def revoke_access(self, revoker_id, revokee_id, model_id):
+        """
+        Revoke previously granted model access.
+
+        :param revoker_id: ID of the client revoking access
+        :type revoker_id: str
+        :param revokee_id: ID of the client whose access is being revoked
+        :type revokee_id: str
+        :param model_id: ID of the model
+        :type model_id: str
+        :return: True if successful, False otherwise
+        """
+        response = self.loop.run_until_complete(
+            self.send_message("revoke_access", {
+                "revoker_id": revoker_id,
+                "revokee_id": revokee_id,
+                "model_id": model_id,
+            })
+        )
+        return "error" not in response
+
+    def get_allowance(self, allower_id):
+        """
+        Get the list of all allowees and their allowed models from a given allower.
+
+        :param allower_id: ID of the allower
+        :type allower_id: str
+        :return: dict of allowees to model lists
+        """
+        response = self.loop.run_until_complete(
+            self.send_message("get_allowance", {"allower_id": allower_id})
+        )
+        self._check_response_error(response)
+        return response["allowance"]
+
+    def get_allowed_models(self, allower_id, allowee_id):
+        """
+        Get the list of models that one client is allowed to access from another.
+
+        :param allower_id: ID of the model owner
+        :type allower_id: str
+        :param allowee_id: ID of the requesting client
+        :type allowee_id: str
+        :return: list of model IDs
+        """
+        response = self.loop.run_until_complete(
+            self.send_message("get_allowed_models", {
+                "allower_id": allower_id,
+                "allowee_id": allowee_id,
+            })
+        )
+        self._check_response_error(response)
+        return response["allowed_models"]
 
 
 class WebSocketServerCommunicator:
@@ -522,6 +708,21 @@ class WebSocketServerCommunicator:
         self.port = port
         self.app = FastAPI()
         self.active_connections: list[WebSocket] = []
+        self._action_handlers = {
+            "register_client": self._handle_register_client,
+            "remove_client": self._handle_remove_client,
+            "register_model": self._handle_register_model,
+            "remove_model": self._handle_remove_model,
+            "get_ml_models": self._handle_get_ml_models,
+            "grant_access": self._handle_grant_access,
+            "revoke_access": self._handle_revoke_access,
+            "get_allowance": self._handle_get_allowance,
+            "get_allowed_models": self._handle_get_allowed_models,
+            "download": self._handle_download,
+            "upload": self._handle_upload,
+            "attribute_call": self._handle_attribute_call,
+            "attribute_type": self._handle_attribute_type,
+        }
         self.setup_routes()
 
     def setup_routes(self):
@@ -541,7 +742,7 @@ class WebSocketServerCommunicator:
         Accept a WebSocket connection and store it.
 
         :param websocket: the WebSocket connection to accept.
-        :type websocket: webSocket
+        :type websocket: WebSocket
         """
         await websocket.accept()
         self.active_connections.append(websocket)
@@ -551,7 +752,7 @@ class WebSocketServerCommunicator:
         Handle WebSocket disconnection.
 
         :param websocket: the WebSocket connection to remove.
-        :type websocket: webSocket
+        :type websocket: WebSocket
         """
         self.active_connections.remove(websocket)
 
@@ -560,24 +761,20 @@ class WebSocketServerCommunicator:
         Handle messages received from WebSocket clients.
 
         :param websocket: the WebSocket connection from which the message was received.
-        :type websocket: webSocket
+        :type websocket: WebSocket
         :param message: the message received from the client.
         :type message: str
         """
         try:
             message = json.loads(message)
-            action = message['action']
+            action = message.get("action")
             print(f"Server received action: {action}")
-            payload = self.parse(message['payload'])
+            raw_payload = message.get("payload", {})
+            payload = self.parse(raw_payload) if raw_payload else {}
 
-            if action == "download":
-                response = self._handle_download(payload)
-            elif action == "upload":
-                response = self._handle_upload(payload)
-            elif action == "attribute_call":
-                response = self._handle_attribute_call(payload)
-            elif action == "attribute_type":
-                response = self._handle_attribute_type(payload)
+            handler = self._action_handlers.get(action)
+            if handler:
+                response = handler(payload)
             else:
                 response = {"error": f"Unknown action: {action}"}
 
@@ -585,7 +782,172 @@ class WebSocketServerCommunicator:
         except Exception as e:
             await websocket.send_text(json.dumps({"error": str(e)}))
 
-    def _handle_download(self, payload) -> dict:
+    def _handle_register_client(self, payload: dict) -> dict:
+        """
+        Handle client registration requests.
+
+        :param payload: the payload (empty for this action).
+        :type payload: dict
+        :return: a response containing the newly allocated client ID.
+        """
+        client_id = str(uuid.uuid4())
+        self._ps.init_client(client_id)
+        return {
+            "message": "Client registered successfully.",
+            "client_id": client_id,
+        }
+
+    def _handle_remove_client(self, payload: dict) -> dict:
+        """
+        Handle client removal requests.
+
+        :param payload: the payload containing the client ID to remove.
+        :type payload: dict
+        :return: a response indicating success or failure.
+        """
+        client_id = payload.get("client_id")
+        is_succeed, detail_message = self._ps.remove_client(client_id)
+        if not is_succeed:
+            return {"error": detail_message}
+        return {
+            "message": "Client removed successfully.",
+            "client_id": client_id,
+        }
+
+    def _handle_register_model(self, payload: dict) -> dict:
+        """
+        Handle ML model registration requests.
+
+        :param payload: the payload containing the client ID.
+        :type payload: dict
+        :return: a response containing the newly allocated model ID.
+        """
+        client_id = payload.get("client_id")
+        ml_model_id = str(uuid.uuid4())
+        is_succeed, detail_message = self._ps.init_ml_model(client_id, ml_model_id)
+        if not is_succeed:
+            return {"error": detail_message}
+        return {
+            "message": "Model registered successfully.",
+            "client_id": client_id,
+            "ml_model_id": ml_model_id,
+        }
+
+    def _handle_remove_model(self, payload: dict) -> dict:
+        """
+        Handle ML model removal requests.
+
+        :param payload: the payload containing the client ID and model ID.
+        :type payload: dict
+        :return: a response indicating success or failure.
+        """
+        client_id = payload.get("client_id")
+        ml_model_id = payload.get("ml_model_id")
+        is_succeed, detail_message = self._ps.remove_ml_model(client_id, ml_model_id)
+        if not is_succeed:
+            return {"error": detail_message}
+        return {
+            "message": "Model removed successfully.",
+            "client_id": client_id,
+            "ml_model_id": ml_model_id,
+        }
+
+    def _handle_get_ml_models(self, payload: dict) -> dict:
+        """
+        Handle requests to get all ML models for a client.
+
+        :param payload: the payload containing the client ID.
+        :type payload: dict
+        :return: a response containing the list of model IDs.
+        """
+        client_id = payload.get("client_id")
+        return {
+            "message": "ML models retrieved successfully.",
+            "client_id": client_id,
+            "ml_models_id": self._ps.get_ml_models(client_id),
+        }
+
+    def _handle_grant_access(self, payload: dict) -> dict:
+        """
+        Handle requests to grant model access to another client.
+
+        :param payload: the payload containing allower_id, allowee_id, and model_id.
+        :type payload: dict
+        :return: a response indicating success or failure.
+        """
+        allower_id = payload.get("allower_id")
+        allowee_id = payload.get("allowee_id")
+        model_id = payload.get("model_id")
+        is_succeed, detail_message = self._ps.grant_access(allower_id, allowee_id, model_id)
+        if not is_succeed:
+            return {"error": detail_message}
+        return {
+            "message": "Access granted successfully.",
+            "allower_id": allower_id,
+            "allowee_id": allowee_id,
+            "allowed_model_id": model_id,
+        }
+
+    def _handle_revoke_access(self, payload: dict) -> dict:
+        """
+        Handle requests to revoke model access from another client.
+
+        :param payload: the payload containing revoker_id, revokee_id, and model_id.
+        :type payload: dict
+        :return: a response indicating success or failure.
+        """
+        revoker_id = payload.get("revoker_id")
+        revokee_id = payload.get("revokee_id")
+        model_id = payload.get("model_id")
+        is_succeed, detail_message = self._ps.revoke_access(revoker_id, revokee_id, model_id)
+        if not is_succeed:
+            return {"error": detail_message}
+        return {
+            "message": "Access revoked successfully.",
+            "revoker_id": revoker_id,
+            "revokee_id": revokee_id,
+            "revoked_model_id": model_id,
+        }
+
+    def _handle_get_allowance(self, payload: dict) -> dict:
+        """
+        Handle requests to get all allowances for a client.
+
+        :param payload: the payload containing the allower_id.
+        :type payload: dict
+        :return: a response containing the allowance dictionary.
+        """
+        allower_id = payload.get("allower_id")
+        allowance, reason = self._ps.get_clients_allowance(allower_id)
+        if allowance is None:
+            return {"error": reason}
+        return {
+            "message": "Allowance retrieved successfully.",
+            "allower_id": allower_id,
+            "allowance": allowance,
+        }
+
+    def _handle_get_allowed_models(self, payload: dict) -> dict:
+        """
+        Handle requests to get allowed models for a specific allowee.
+
+        :param payload: the payload containing allower_id and allowee_id.
+        :type payload: dict
+        :return: a response containing the list of allowed model IDs.
+        """
+        allower_id = payload.get("allower_id")
+        allowee_id = payload.get("allowee_id")
+        models, reason = self._ps.get_allowed_models(allower_id, allowee_id)
+        if models is None:
+            return {"error": reason}
+        return {
+            "message": "Allowed models retrieved successfully.",
+            "allower_id": allower_id,
+            "allowee_id": allowee_id,
+            "allowed_models": models,
+        }
+
+    def _handle_download(self, payload: dict) -> dict:
         """
         Handle download requests.
 
@@ -593,12 +955,14 @@ class WebSocketServerCommunicator:
         :type payload: dict
         :return: a response containing the exported model.
         """
+        client_id = payload.get("client_id")
+        ml_model_id = payload.get("ml_model_id")
+        is_valid, reason = self._ps._validate_id(client_id, ml_model_id)
+        if not is_valid:
+            return {"error": reason}
         return {
-            "message": "Download request received.",
-            "payload": self._ps.export_model(
-                payload["client_id"],
-                payload["ml_model_id"],
-            ),
+            "message": f"Download request from client: {client_id} for model: {ml_model_id}",
+            "payload": self._ps.export_model(client_id, ml_model_id),
         }
 
     def _handle_upload(self, payload: dict) -> dict:
@@ -609,9 +973,21 @@ class WebSocketServerCommunicator:
         :type payload: dict
         :return: a response indicating that the upload was processed.
         """
+        client_id = payload.get("client_id")
+        ml_model_id = payload.get("ml_model_id")
+        encrypted_model = payload.get("model")
+        if encrypted_model is None:
+            return {"error": "Missing 'model' in request"}
+        decrypted_model = self.parse(encrypted_model)
+        model_data = decrypted_model.get("model")
+        if model_data is None:
+            return {"error": "Missing 'model' in decrypted request"}
+        is_valid, reason = self._ps._validate_id(client_id, ml_model_id)
+        if not is_valid:
+            return {"error": reason}
+        self._ps.update_model(client_id, ml_model_id, model_data)
         return {
-            "message": "Upload request received.",
-            "payload": self._ps.update_model(payload["model"]),
+            "message": f"Upload request from client: {client_id} for model: {ml_model_id}",
         }
 
     def _handle_attribute_call(self, payload: dict) -> dict:
@@ -622,9 +998,18 @@ class WebSocketServerCommunicator:
         :type payload: dict
         :return: a response with the result of the attribute call.
         """
-        result = self._ps.execute_model(payload)
+        client_id = payload.get("client_id")
+        ml_model_id = payload.get("ml_model_id")
+        encrypted_call_payload = payload.get("call_payload")
+        if encrypted_call_payload is None:
+            return {"error": "Missing 'call_payload' in request"}
+        call_payload = self.parse(encrypted_call_payload)
+        is_valid, reason = self._ps._validate_id(client_id, ml_model_id)
+        if not is_valid:
+            return {"error": reason}
+        result = self._ps.execute_model(call_payload)
         return {
-            "message": "Attribute call executed.",
+            "message": f"Attribute call request from client: {client_id} for model: {ml_model_id}",
             "payload": result if result else "The ML model has been updated in place.",
         }
 
@@ -636,21 +1021,32 @@ class WebSocketServerCommunicator:
         :type payload: dict
         :return: a response with the attribute type and value.
         """
-        is_callable, field_value = self._ps.is_callable_attribute(payload)
+        client_id = payload.get("client_id")
+        ml_model_id = payload.get("ml_model_id")
+        encrypted_type_payload = payload.get("type_payload")
+        if encrypted_type_payload is None:
+            return {"error": "Missing 'type_payload' in request"}
+        type_payload = self.parse(encrypted_type_payload)
+        is_valid, reason = self._ps._validate_id(client_id, ml_model_id)
+        if not is_valid:
+            return {"error": reason}
+        is_callable, field_value = self._ps.is_callable_attribute(type_payload)
         return {
-            "message": "Attribute type query executed.",
+            "message": f"Attribute type request from client: {client_id} for model: {ml_model_id}",
             "attribute type": "method" if is_callable else "field",
             "attribute value": "" if is_callable else field_value,
         }
 
-    def parse(self, message: str) -> dict:
+    def parse(self, message) -> dict:
         """
         Parse the encrypted and compressed message.
 
         :param message: the encrypted and compressed message to parse.
-        :type message: str
+        :type message: str | dict
         :return: the decrypted and extracted version of the message.
         """
+        if isinstance(message, dict):
+            return message
         return json.loads(
             self._ps._compressor.extract(
                 self._ps._encryptor.decrypt(message)

--- a/pymilo/streaming/communicator.py
+++ b/pymilo/streaming/communicator.py
@@ -432,10 +432,8 @@ class WebSocketClientCommunicator(ClientCommunicator):
         to ensure proper cleanup.
         """
         if self.websocket and not self.is_socket_closed():
-            try:
+            if self.loop and not self.loop.is_closed():
                 self.loop.run_until_complete(self.disconnect())
-            except RuntimeError:
-                pass
 
     def __del__(self):
         """Clean up WebSocket connection on object destruction."""

--- a/pymilo/streaming/communicator.py
+++ b/pymilo/streaming/communicator.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 """PyMilo Communication Mediums."""
+from __future__ import annotations
+
 import uuid
 import json
 import asyncio
+from typing import Any, Dict, List, Optional, Union
 import uvicorn
 import requests
 import websockets
@@ -16,13 +19,11 @@ from .util import validate_websocket_url, validate_http_url
 class RESTClientCommunicator(ClientCommunicator):
     """Facilitate working with the communication medium from the client side for the REST protocol."""
 
-    def __init__(self, server_url):
+    def __init__(self, server_url: str) -> None:
         """
         Initialize the Pymilo RESTClientCommunicator instance.
 
         :param server_url: the url to which PyMilo Server listens
-        :type server_url: str
-        :return: an instance of the Pymilo RESTClientCommunicator class
         """
         is_valid, server_url = validate_http_url(server_url)
         if not is_valid:
@@ -51,7 +52,7 @@ class RESTClientCommunicator(ClientCommunicator):
         response.raise_for_status()
         return response.json()["payload"]
 
-    def upload(self, client_id, model_id, model):
+    def upload(self, client_id: str, model_id: str, model: Any) -> bool:
         """
         Upload the local ML model to the remote server.
 
@@ -78,7 +79,7 @@ class RESTClientCommunicator(ClientCommunicator):
         response.raise_for_status()
         return response.json()
 
-    def attribute_type(self, client_id, model_id, type_payload):
+    def attribute_type(self, client_id: str, model_id: str, type_payload: Dict) -> Dict:
         """
         Identify the attribute type of the requested attribute.
 
@@ -92,7 +93,7 @@ class RESTClientCommunicator(ClientCommunicator):
         response.raise_for_status()
         return response.json()
 
-    def register_client(self):
+    def register_client(self) -> str:
         """
         Register client in the PyMiloServer.
 
@@ -102,55 +103,50 @@ class RESTClientCommunicator(ClientCommunicator):
         response.raise_for_status()
         return response.json()["client_id"]
 
-    def remove_client(self, client_id):
+    def remove_client(self, client_id: str) -> bool:
         """
         Remove client from the PyMiloServer.
 
         :param client_id: id of the client to remove
-        :type client_id: str
         :return: True if removal was successful, False otherwise
         """
         response = self.session.delete(f"{self._server_url}/clients/{client_id}", timeout=5)
         return response.status_code == 200
 
-    def register_model(self, client_id):
+    def register_model(self, client_id: str) -> str:
         """
         Register ML model in the PyMiloServer.
 
         :param client_id: id of the client who owns the model
-        :type client_id: str
         :return: newly allocated ml model id
         """
         response = self.session.post(f"{self._server_url}/clients/{client_id}/models/register", timeout=5)
         response.raise_for_status()
         return response.json()["ml_model_id"]
 
-    def remove_model(self, client_id, model_id):
+    def remove_model(self, client_id: str, model_id: str) -> bool:
         """
         Remove ML model from the PyMiloServer.
 
         :param client_id: client owning the model
-        :type client_id: str
         :param model_id: model to remove
-        :type model_id: str
         :return: True if removal was successful, False otherwise
         """
         response = self.session.delete(f"{self._server_url}/clients/{client_id}/models/{model_id}", timeout=5)
         return response.status_code == 200
 
-    def get_ml_models(self, client_id):
+    def get_ml_models(self, client_id: str) -> List[str]:
         """
         Get all ML models registered for this specific client in the PyMiloServer.
 
         :param client_id: client whose models are being queried
-        :type client_id: str
         :return: list of ml model ids
         """
         response = self.session.get(f"{self._server_url}/clients/{client_id}/models", timeout=5)
         response.raise_for_status()
         return response.json()["ml_models_id"]
 
-    def grant_access(self, allower_id, allowee_id, model_id):
+    def grant_access(self, allower_id: str, allowee_id: str, model_id: str) -> bool:
         """
         Grant access to a model to another client.
 
@@ -163,7 +159,7 @@ class RESTClientCommunicator(ClientCommunicator):
         response = self.session.post(url, timeout=5)
         return response.status_code == 200
 
-    def revoke_access(self, revoker_id, revokee_id, model_id):
+    def revoke_access(self, revoker_id: str, revokee_id: str, model_id: str) -> bool:
         """
         Revoke previously granted model access.
 
@@ -176,7 +172,7 @@ class RESTClientCommunicator(ClientCommunicator):
         response = self.session.post(url, timeout=5)
         return response.status_code == 200
 
-    def get_allowance(self, allower_id):
+    def get_allowance(self, allower_id: str) -> Dict[str, List[str]]:
         """
         Get the list of all allowees and their allowed models from a given allower.
 
@@ -187,7 +183,7 @@ class RESTClientCommunicator(ClientCommunicator):
         response.raise_for_status()
         return response.json()["allowance"]
 
-    def get_allowed_models(self, allower_id, allowee_id):
+    def get_allowed_models(self, allower_id: str, allowee_id: str) -> List[str]:
         """
         Get the list of models that one client is allowed to access from another.
 
@@ -214,12 +210,8 @@ class RESTServerCommunicator():
         Initialize the Pymilo RESTServerCommunicator instance.
 
         :param ps: reference to the PyMilo server
-        :type ps: pymilo.streaming.PymiloServer
         :param host: the url to which PyMilo Server listens
-        :type host: str
         :param port: the port to which PyMilo Server listens
-        :type port: int
-        :return: an instance of the Pymilo RESTServerCommunicator class
         """
         self._ps = ps
         self.host = host
@@ -357,7 +349,6 @@ class RESTServerCommunicator():
         Parse the compressed encrypted body of the request.
 
         :param body: request body
-        :type body: str
         :return: the extracted decrypted version
         """
         return json.loads(
@@ -382,8 +373,6 @@ class WebSocketClientCommunicator(ClientCommunicator):
         Initialize the WebSocketClientCommunicator instance.
 
         :param server_url: the WebSocket server URL to connect to.
-        :type server_url: str
-        :return: an instance of the Pymilo WebSocketClientCommunicator class
         """
         is_valid, url = validate_websocket_url(server_url)
         if not is_valid:
@@ -424,31 +413,31 @@ class WebSocketClientCommunicator(ClientCommunicator):
             await self.websocket.close()
             self.websocket = None
 
-    def close(self):
+    def _disconnect_sync(self) -> None:
+        """Close the WebSocket connection synchronously if still open."""
+        if self.websocket and not self.is_socket_closed():
+            if self.loop and not self.loop.is_closed():
+                self.loop.run_until_complete(self.disconnect())
+
+    def close(self) -> None:
         """
         Close the WebSocket connection synchronously.
 
         This method should be called before the event loop is closed
         to ensure proper cleanup.
         """
-        if self.websocket and not self.is_socket_closed():
-            if self.loop and not self.loop.is_closed():
-                self.loop.run_until_complete(self.disconnect())
+        self._disconnect_sync()
 
-    def __del__(self):
+    def __del__(self) -> None:
         """Clean up WebSocket connection on object destruction."""
-        if self.websocket and not self.is_socket_closed():
-            if self.loop and not self.loop.is_closed():
-                self.loop.run_until_complete(self.disconnect())
+        self._disconnect_sync()
 
-    async def send_message(self, action: str, payload: dict = None) -> dict:
+    async def send_message(self, action: str, payload: Optional[Dict] = None) -> Dict:
         """
         Send a message to the WebSocket server.
 
         :param action: the type of action to perform (e.g., 'download', 'upload').
-        :type action: str
         :param payload: the payload associated with the action.
-        :type payload: dict
         :return: the server's response as a JSON object.
         """
         await self.connection_established.wait()
@@ -461,26 +450,21 @@ class WebSocketClientCommunicator(ClientCommunicator):
         response = await self.websocket.recv()
         return json.loads(response)
 
-    def _check_response_error(self, response: dict) -> None:
+    def _check_response_error(self, response: Dict) -> None:
         """
         Check if the server response contains an error and raise an exception if so.
 
         :param response: the server's response.
-        :type response: dict
-        :return: None
-        :raises RuntimeError: if the response contains an error.
         """
         if "error" in response:
             raise RuntimeError(response["error"])
 
-    def download(self, client_id, model_id):
+    def download(self, client_id: str, model_id: str) -> str:
         """
         Request for the remote ML model to download.
 
         :param client_id: ID of the requesting client
-        :type client_id: str
         :param model_id: ID of the model to download
-        :type model_id: str
         :return: string serialized model
         """
         response = self.loop.run_until_complete(
@@ -492,14 +476,12 @@ class WebSocketClientCommunicator(ClientCommunicator):
         self._check_response_error(response)
         return response.get("payload")
 
-    def upload(self, client_id, model_id, model):
+    def upload(self, client_id: str, model_id: str, model: Any) -> bool:
         """
         Upload the local ML model to the remote server.
 
         :param client_id: ID of the client
-        :type client_id: str
         :param model_id: ID of the model
-        :type model_id: str
         :param model: serialized model content
         :return: True if upload was successful, False otherwise
         """
@@ -512,14 +494,12 @@ class WebSocketClientCommunicator(ClientCommunicator):
         )
         return "error" not in response
 
-    def attribute_call(self, client_id, model_id, call_payload):
+    def attribute_call(self, client_id: str, model_id: str, call_payload: Dict) -> Dict:
         """
         Delegate the requested attribute call to the remote server.
 
         :param client_id: ID of the client
-        :type client_id: str
         :param model_id: ID of the model
-        :type model_id: str
         :param call_payload: payload containing attribute name, args, and kwargs
         :return: json-encoded response of pymilo server
         """
@@ -533,14 +513,12 @@ class WebSocketClientCommunicator(ClientCommunicator):
         self._check_response_error(response)
         return response
 
-    def attribute_type(self, client_id, model_id, type_payload):
+    def attribute_type(self, client_id: str, model_id: str, type_payload: Dict) -> Dict:
         """
         Identify the attribute type of the requested attribute.
 
         :param client_id: ID of the client
-        :type client_id: str
         :param model_id: ID of the model
-        :type model_id: str
         :param type_payload: payload containing attribute data to inspect
         :return: response of pymilo server
         """
@@ -554,7 +532,7 @@ class WebSocketClientCommunicator(ClientCommunicator):
         self._check_response_error(response)
         return response
 
-    def register_client(self):
+    def register_client(self) -> str:
         """
         Register client in the PyMiloServer.
 
@@ -566,12 +544,11 @@ class WebSocketClientCommunicator(ClientCommunicator):
         self._check_response_error(response)
         return response["client_id"]
 
-    def remove_client(self, client_id):
+    def remove_client(self, client_id: str) -> bool:
         """
         Remove client from the PyMiloServer.
 
         :param client_id: id of the client to remove
-        :type client_id: str
         :return: True if removal was successful, False otherwise
         """
         response = self.loop.run_until_complete(
@@ -593,14 +570,12 @@ class WebSocketClientCommunicator(ClientCommunicator):
         self._check_response_error(response)
         return response["ml_model_id"]
 
-    def remove_model(self, client_id, model_id):
+    def remove_model(self, client_id: str, model_id: str) -> bool:
         """
         Remove ML model from the PyMiloServer.
 
         :param client_id: client owning the model
-        :type client_id: str
         :param model_id: model to remove
-        :type model_id: str
         :return: True if removal was successful, False otherwise
         """
         response = self.loop.run_until_complete(
@@ -611,12 +586,11 @@ class WebSocketClientCommunicator(ClientCommunicator):
         )
         return "error" not in response
 
-    def get_ml_models(self, client_id):
+    def get_ml_models(self, client_id: str) -> List[str]:
         """
         Get all ML models registered for this specific client in the PyMiloServer.
 
         :param client_id: client whose models are being queried
-        :type client_id: str
         :return: list of ml model ids
         """
         response = self.loop.run_until_complete(
@@ -625,16 +599,13 @@ class WebSocketClientCommunicator(ClientCommunicator):
         self._check_response_error(response)
         return response["ml_models_id"]
 
-    def grant_access(self, allower_id, allowee_id, model_id):
+    def grant_access(self, allower_id: str, allowee_id: str, model_id: str) -> bool:
         """
         Grant access to a model to another client.
 
         :param allower_id: ID of the client granting access
-        :type allower_id: str
         :param allowee_id: ID of the client being granted access
-        :type allowee_id: str
         :param model_id: ID of the model being shared
-        :type model_id: str
         :return: True if successful, False otherwise
         """
         response = self.loop.run_until_complete(
@@ -646,16 +617,13 @@ class WebSocketClientCommunicator(ClientCommunicator):
         )
         return "error" not in response
 
-    def revoke_access(self, revoker_id, revokee_id, model_id):
+    def revoke_access(self, revoker_id: str, revokee_id: str, model_id: str) -> bool:
         """
         Revoke previously granted model access.
 
         :param revoker_id: ID of the client revoking access
-        :type revoker_id: str
         :param revokee_id: ID of the client whose access is being revoked
-        :type revokee_id: str
         :param model_id: ID of the model
-        :type model_id: str
         :return: True if successful, False otherwise
         """
         response = self.loop.run_until_complete(
@@ -672,7 +640,6 @@ class WebSocketClientCommunicator(ClientCommunicator):
         Get the list of all allowees and their allowed models from a given allower.
 
         :param allower_id: ID of the allower
-        :type allower_id: str
         :return: dict of allowees to model lists
         """
         response = self.loop.run_until_complete(
@@ -681,14 +648,12 @@ class WebSocketClientCommunicator(ClientCommunicator):
         self._check_response_error(response)
         return response["allowance"]
 
-    def get_allowed_models(self, allower_id, allowee_id):
+    def get_allowed_models(self, allower_id: str, allowee_id: str) -> List[str]:
         """
         Get the list of models that one client is allowed to access from another.
 
         :param allower_id: ID of the model owner
-        :type allower_id: str
         :param allowee_id: ID of the requesting client
-        :type allowee_id: str
         :return: list of model IDs
         """
         response = self.loop.run_until_complete(
@@ -714,12 +679,8 @@ class WebSocketServerCommunicator:
         Initialize the WebSocketServerCommunicator instance.
 
         :param ps: reference to the PyMilo server.
-        :type ps: pymilo.streaming.PymiloServer
         :param host: the WebSocket server host address.
-        :type host: str
         :param port: the WebSocket server port.
-        :type port: int
-        :return: an instance of the WebSocketServerCommunicator class.
         """
         self._ps = ps
         self.host = host
@@ -755,12 +716,11 @@ class WebSocketServerCommunicator:
             except WebSocketDisconnect:
                 self.disconnect(websocket)
 
-    async def connect(self, websocket: WebSocket):
+    async def connect(self, websocket: WebSocket) -> None:
         """
         Accept a WebSocket connection and store it.
 
         :param websocket: the WebSocket connection to accept.
-        :type websocket: WebSocket
         """
         await websocket.accept()
         self.active_connections.append(websocket)
@@ -774,14 +734,12 @@ class WebSocketServerCommunicator:
         """
         self.active_connections.remove(websocket)
 
-    async def handle_message(self, websocket: WebSocket, message: str):
+    async def handle_message(self, websocket: WebSocket, message: str) -> None:
         """
         Handle messages received from WebSocket clients.
 
         :param websocket: the WebSocket connection from which the message was received.
-        :type websocket: WebSocket
         :param message: the message received from the client.
-        :type message: str
         """
         try:
             message = json.loads(message)
@@ -805,7 +763,6 @@ class WebSocketServerCommunicator:
         Handle client registration requests.
 
         :param payload: the payload (empty for this action).
-        :type payload: dict
         :return: a response containing the newly allocated client ID.
         """
         client_id = str(uuid.uuid4())
@@ -820,7 +777,6 @@ class WebSocketServerCommunicator:
         Handle client removal requests.
 
         :param payload: the payload containing the client ID to remove.
-        :type payload: dict
         :return: a response indicating success or failure.
         """
         client_id = payload.get("client_id")
@@ -837,7 +793,6 @@ class WebSocketServerCommunicator:
         Handle ML model registration requests.
 
         :param payload: the payload containing the client ID.
-        :type payload: dict
         :return: a response containing the newly allocated model ID.
         """
         client_id = payload.get("client_id")
@@ -856,7 +811,6 @@ class WebSocketServerCommunicator:
         Handle ML model removal requests.
 
         :param payload: the payload containing the client ID and model ID.
-        :type payload: dict
         :return: a response indicating success or failure.
         """
         client_id = payload.get("client_id")
@@ -875,7 +829,6 @@ class WebSocketServerCommunicator:
         Handle requests to get all ML models for a client.
 
         :param payload: the payload containing the client ID.
-        :type payload: dict
         :return: a response containing the list of model IDs.
         """
         client_id = payload.get("client_id")
@@ -890,7 +843,6 @@ class WebSocketServerCommunicator:
         Handle requests to grant model access to another client.
 
         :param payload: the payload containing allower_id, allowee_id, and model_id.
-        :type payload: dict
         :return: a response indicating success or failure.
         """
         allower_id = payload.get("allower_id")
@@ -911,7 +863,6 @@ class WebSocketServerCommunicator:
         Handle requests to revoke model access from another client.
 
         :param payload: the payload containing revoker_id, revokee_id, and model_id.
-        :type payload: dict
         :return: a response indicating success or failure.
         """
         revoker_id = payload.get("revoker_id")
@@ -932,7 +883,6 @@ class WebSocketServerCommunicator:
         Handle requests to get all allowances for a client.
 
         :param payload: the payload containing the allower_id.
-        :type payload: dict
         :return: a response containing the allowance dictionary.
         """
         allower_id = payload.get("allower_id")
@@ -950,7 +900,6 @@ class WebSocketServerCommunicator:
         Handle requests to get allowed models for a specific allowee.
 
         :param payload: the payload containing allower_id and allowee_id.
-        :type payload: dict
         :return: a response containing the list of allowed model IDs.
         """
         allower_id = payload.get("allower_id")
@@ -970,7 +919,6 @@ class WebSocketServerCommunicator:
         Handle download requests.
 
         :param payload: the payload containing the ids associated with the requested model for download.
-        :type payload: dict
         :return: a response containing the exported model.
         """
         client_id = payload.get("client_id")
@@ -988,7 +936,6 @@ class WebSocketServerCommunicator:
         Handle upload requests.
 
         :param payload: the payload containing the model data to upload.
-        :type payload: dict
         :return: a response indicating that the upload was processed.
         """
         client_id = payload.get("client_id")
@@ -1013,7 +960,6 @@ class WebSocketServerCommunicator:
         Handle attribute call requests.
 
         :param payload: the payload containing the attribute call details.
-        :type payload: dict
         :return: a response with the result of the attribute call.
         """
         client_id = payload.get("client_id")
@@ -1036,7 +982,6 @@ class WebSocketServerCommunicator:
         Handle attribute type queries.
 
         :param payload: the payload containing the attribute to query.
-        :type payload: dict
         :return: a response with the attribute type and value.
         """
         client_id = payload.get("client_id")
@@ -1055,12 +1000,11 @@ class WebSocketServerCommunicator:
             "attribute value": "" if is_callable else field_value,
         }
 
-    def parse(self, message) -> dict:
+    def parse(self, message: Union[str, Dict]) -> Dict:
         """
         Parse the encrypted and compressed message.
 
         :param message: the encrypted and compressed message to parse.
-        :type message: str | dict
         :return: the decrypted and extracted version of the message.
         """
         if isinstance(message, dict):

--- a/pymilo/streaming/communicator.py
+++ b/pymilo/streaming/communicator.py
@@ -426,7 +426,7 @@ class WebSocketClientCommunicator(ClientCommunicator):
 
     def close(self):
         """
-        Synchronously close the WebSocket connection.
+        Close the WebSocket connection synchronously.
 
         This method should be called before the event loop is closed
         to ensure proper cleanup.
@@ -439,12 +439,9 @@ class WebSocketClientCommunicator(ClientCommunicator):
 
     def __del__(self):
         """Clean up WebSocket connection on object destruction."""
-        try:
-            if self.websocket and not self.is_socket_closed():
-                if self.loop and not self.loop.is_closed():
-                    self.loop.run_until_complete(self.disconnect())
-        except Exception:
-            pass
+        if self.websocket and not self.is_socket_closed():
+            if self.loop and not self.loop.is_closed():
+                self.loop.run_until_complete(self.disconnect())
 
     async def send_message(self, action: str, payload: dict = None) -> dict:
         """

--- a/pymilo/streaming/communicator.py
+++ b/pymilo/streaming/communicator.py
@@ -422,6 +422,29 @@ class WebSocketClientCommunicator(ClientCommunicator):
         """Close the WebSocket connection."""
         if self.websocket:
             await self.websocket.close()
+            self.websocket = None
+
+    def close(self):
+        """
+        Synchronously close the WebSocket connection.
+
+        This method should be called before the event loop is closed
+        to ensure proper cleanup.
+        """
+        if self.websocket and not self.is_socket_closed():
+            try:
+                self.loop.run_until_complete(self.disconnect())
+            except RuntimeError:
+                pass
+
+    def __del__(self):
+        """Clean up WebSocket connection on object destruction."""
+        try:
+            if self.websocket and not self.is_socket_closed():
+                if self.loop and not self.loop.is_closed():
+                    self.loop.run_until_complete(self.disconnect())
+        except Exception:
+            pass
 
     async def send_message(self, action: str, payload: dict = None) -> dict:
         """

--- a/pymilo/streaming/communicator.py
+++ b/pymilo/streaming/communicator.py
@@ -12,7 +12,19 @@ import websockets
 from enum import Enum
 from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect, HTTPException
 from .interfaces import ClientCommunicator
-from .param import PYMILO_INVALID_URL, PYMILO_CLIENT_WEBSOCKET_NOT_CONNECTED, REST_API_PREFIX
+from .param import (
+    PYMILO_INVALID_URL,
+    PYMILO_CLIENT_WEBSOCKET_NOT_CONNECTED,
+    REST_API_PREFIX,
+    MSG_DOWNLOAD_REQUEST,
+    MSG_UPLOAD_REQUEST,
+    MSG_ATTRIBUTE_CALL_REQUEST,
+    MSG_ATTRIBUTE_TYPE_REQUEST,
+    MSG_REST_DOWNLOAD_REQUEST,
+    MSG_REST_UPLOAD_REQUEST,
+    MSG_REST_ATTRIBUTE_CALL_REQUEST,
+    MSG_REST_ATTRIBUTE_TYPE_REQUEST,
+)
 from .util import validate_websocket_url, validate_http_url
 
 
@@ -39,13 +51,12 @@ class RESTClientCommunicator(ClientCommunicator):
         self.session.mount('http://', adapter)
         self.session.mount('https://', adapter)
 
-    def download(self, client_id, model_id):
+    def download(self, client_id: str, model_id: str) -> str:
         """
         Request for the remote ML model to download.
 
         :param client_id: ID of the requesting client
         :param model_id: ID of the model to download
-        :return: string serialized model
         """
         url = f"{self._server_url}/clients/{client_id}/models/{model_id}/download"
         response = self.session.get(url, timeout=5)
@@ -59,20 +70,18 @@ class RESTClientCommunicator(ClientCommunicator):
         :param client_id: ID of the client
         :param model_id: ID of the model
         :param model: serialized model content
-        :return: True if upload was successful, False otherwise
         """
         url = f"{self._server_url}/clients/{client_id}/models/{model_id}/upload"
         response = self.session.post(url, json=model, timeout=5)
         return response.status_code == 200
 
-    def attribute_call(self, client_id, model_id, call_payload):
+    def attribute_call(self, client_id: str, model_id: str, call_payload: Dict) -> Dict:
         """
         Delegate the requested attribute call to the remote server.
 
         :param client_id: ID of the client
         :param model_id: ID of the model
         :param call_payload: payload containing attribute name, args, and kwargs
-        :return: json-encoded response of pymilo server
         """
         url = f"{self._server_url}/clients/{client_id}/models/{model_id}/attribute-call"
         response = self.session.post(url, json=call_payload, timeout=5)
@@ -86,7 +95,6 @@ class RESTClientCommunicator(ClientCommunicator):
         :param client_id: ID of the client
         :param model_id: ID of the model
         :param type_payload: payload containing attribute data to inspect
-        :return: response of pymilo server
         """
         url = f"{self._server_url}/clients/{client_id}/models/{model_id}/attribute-type"
         response = self.session.post(url, json=type_payload, timeout=5)
@@ -94,11 +102,7 @@ class RESTClientCommunicator(ClientCommunicator):
         return response.json()
 
     def register_client(self) -> str:
-        """
-        Register client in the PyMiloServer.
-
-        :return: newly allocated client id
-        """
+        """Register client in the PyMiloServer."""
         response = self.session.get(f"{self._server_url}/clients/register", timeout=5)
         response.raise_for_status()
         return response.json()["client_id"]
@@ -108,7 +112,6 @@ class RESTClientCommunicator(ClientCommunicator):
         Remove client from the PyMiloServer.
 
         :param client_id: id of the client to remove
-        :return: True if removal was successful, False otherwise
         """
         response = self.session.delete(f"{self._server_url}/clients/{client_id}", timeout=5)
         return response.status_code == 200
@@ -118,7 +121,6 @@ class RESTClientCommunicator(ClientCommunicator):
         Register ML model in the PyMiloServer.
 
         :param client_id: id of the client who owns the model
-        :return: newly allocated ml model id
         """
         response = self.session.post(f"{self._server_url}/clients/{client_id}/models/register", timeout=5)
         response.raise_for_status()
@@ -130,7 +132,6 @@ class RESTClientCommunicator(ClientCommunicator):
 
         :param client_id: client owning the model
         :param model_id: model to remove
-        :return: True if removal was successful, False otherwise
         """
         response = self.session.delete(f"{self._server_url}/clients/{client_id}/models/{model_id}", timeout=5)
         return response.status_code == 200
@@ -140,7 +141,6 @@ class RESTClientCommunicator(ClientCommunicator):
         Get all ML models registered for this specific client in the PyMiloServer.
 
         :param client_id: client whose models are being queried
-        :return: list of ml model ids
         """
         response = self.session.get(f"{self._server_url}/clients/{client_id}/models", timeout=5)
         response.raise_for_status()
@@ -153,7 +153,6 @@ class RESTClientCommunicator(ClientCommunicator):
         :param allower_id: ID of the client granting access
         :param allowee_id: ID of the client being granted access
         :param model_id: ID of the model being shared
-        :return: True if successful, False otherwise
         """
         url = f"{self._server_url}/clients/{allower_id}/grant/{allowee_id}/models/{model_id}"
         response = self.session.post(url, timeout=5)
@@ -166,7 +165,6 @@ class RESTClientCommunicator(ClientCommunicator):
         :param revoker_id: ID of the client revoking access
         :param revokee_id: ID of the client whose access is being revoked
         :param model_id: ID of the model
-        :return: True if successful, False otherwise
         """
         url = f"{self._server_url}/clients/{revoker_id}/revoke/{revokee_id}/models/{model_id}"
         response = self.session.post(url, timeout=5)
@@ -177,7 +175,6 @@ class RESTClientCommunicator(ClientCommunicator):
         Get the list of all allowees and their allowed models from a given allower.
 
         :param allower_id: ID of the allower
-        :return: dict of allowees to model lists
         """
         response = self.session.get(f"{self._server_url}/clients/{allower_id}/allowances", timeout=5)
         response.raise_for_status()
@@ -189,7 +186,6 @@ class RESTClientCommunicator(ClientCommunicator):
 
         :param allower_id: ID of the model owner
         :param allowee_id: ID of the requesting client
-        :return: list of model IDs
         """
         url = f"{self._server_url}/clients/{allower_id}/allowances/{allowee_id}"
         response = self.session.get(url, timeout=5)
@@ -300,7 +296,7 @@ class RESTServerCommunicator():
             if not is_valid:
                 raise HTTPException(status_code=404, detail=reason)
             return {
-                "message": f"/download request from client: {client_id} for model: {ml_model_id}",
+                "message": MSG_REST_DOWNLOAD_REQUEST.format(client_id=client_id, ml_model_id=ml_model_id),
                 "payload": self._ps.export_model(client_id, ml_model_id)
             }
 
@@ -315,7 +311,7 @@ class RESTServerCommunicator():
                 raise HTTPException(status_code=404, detail=reason)
 
             return {
-                "message": f"/upload request from client: {client_id} for model: {ml_model_id}",
+                "message": MSG_REST_UPLOAD_REQUEST.format(client_id=client_id, ml_model_id=ml_model_id),
                 "payload": self._ps.update_model(client_id, ml_model_id, model_data)
             }
 
@@ -327,7 +323,7 @@ class RESTServerCommunicator():
                 raise HTTPException(status_code=404, detail=reason)
             result = self._ps.execute_model(request_payload)
             return {
-                "message": f"/attribute_call request from client: {client_id} for model: {ml_model_id}",
+                "message": MSG_REST_ATTRIBUTE_CALL_REQUEST.format(client_id=client_id, ml_model_id=ml_model_id),
                 "payload": result or "The ML model has been updated in place."
             }
 
@@ -339,17 +335,16 @@ class RESTServerCommunicator():
                 raise HTTPException(status_code=404, detail=reason)
             is_callable, field_value = self._ps.is_callable_attribute(request)
             return {
-                "message": f"/attribute_type request from client: {client_id} for model: {ml_model_id}",
+                "message": MSG_REST_ATTRIBUTE_TYPE_REQUEST.format(client_id=client_id, ml_model_id=ml_model_id),
                 "attribute type": "method" if is_callable else "field",
                 "attribute value": "" if is_callable else field_value,
             }
 
-    def parse(self, body):
+    def parse(self, body: str) -> Dict:
         """
         Parse the compressed encrypted body of the request.
 
         :param body: request body
-        :return: the extracted decrypted version
         """
         return json.loads(
             self._ps._compressor.extract(
@@ -387,12 +382,8 @@ class WebSocketClientCommunicator(ClientCommunicator):
             self.loop = asyncio.get_event_loop()
         self.loop.run_until_complete(self.connect())
 
-    def is_socket_closed(self):
-        """
-        Check if the WebSocket connection is closed.
-
-        :return: `True` if the WebSocket connection is closed or uninitialized, `False` otherwise.
-        """
+    def is_socket_closed(self) -> bool:
+        """Check if the WebSocket connection is closed."""
         if self.websocket is None:
             return True
         elif hasattr(self.websocket, "closed"):
@@ -438,7 +429,6 @@ class WebSocketClientCommunicator(ClientCommunicator):
 
         :param action: the type of action to perform (e.g., 'download', 'upload').
         :param payload: the payload associated with the action.
-        :return: the server's response as a JSON object.
         """
         await self.connection_established.wait()
 
@@ -465,7 +455,6 @@ class WebSocketClientCommunicator(ClientCommunicator):
 
         :param client_id: ID of the requesting client
         :param model_id: ID of the model to download
-        :return: string serialized model
         """
         response = self.loop.run_until_complete(
             self.send_message("download", {
@@ -483,7 +472,6 @@ class WebSocketClientCommunicator(ClientCommunicator):
         :param client_id: ID of the client
         :param model_id: ID of the model
         :param model: serialized model content
-        :return: True if upload was successful, False otherwise
         """
         response = self.loop.run_until_complete(
             self.send_message("upload", {
@@ -492,7 +480,8 @@ class WebSocketClientCommunicator(ClientCommunicator):
                 "model": model,
             })
         )
-        return "error" not in response
+        self._check_response_error(response)
+        return True
 
     def attribute_call(self, client_id: str, model_id: str, call_payload: Dict) -> Dict:
         """
@@ -501,7 +490,6 @@ class WebSocketClientCommunicator(ClientCommunicator):
         :param client_id: ID of the client
         :param model_id: ID of the model
         :param call_payload: payload containing attribute name, args, and kwargs
-        :return: json-encoded response of pymilo server
         """
         response = self.loop.run_until_complete(
             self.send_message("attribute_call", {
@@ -520,7 +508,6 @@ class WebSocketClientCommunicator(ClientCommunicator):
         :param client_id: ID of the client
         :param model_id: ID of the model
         :param type_payload: payload containing attribute data to inspect
-        :return: response of pymilo server
         """
         response = self.loop.run_until_complete(
             self.send_message("attribute_type", {
@@ -533,11 +520,7 @@ class WebSocketClientCommunicator(ClientCommunicator):
         return response
 
     def register_client(self) -> str:
-        """
-        Register client in the PyMiloServer.
-
-        :return: newly allocated client id
-        """
+        """Register client in the PyMiloServer."""
         response = self.loop.run_until_complete(
             self.send_message("register_client")
         )
@@ -549,20 +532,18 @@ class WebSocketClientCommunicator(ClientCommunicator):
         Remove client from the PyMiloServer.
 
         :param client_id: id of the client to remove
-        :return: True if removal was successful, False otherwise
         """
         response = self.loop.run_until_complete(
             self.send_message("remove_client", {"client_id": client_id})
         )
-        return "error" not in response
+        self._check_response_error(response)
+        return True
 
-    def register_model(self, client_id):
+    def register_model(self, client_id: str) -> str:
         """
         Register ML model in the PyMiloServer.
 
         :param client_id: id of the client who owns the model
-        :type client_id: str
-        :return: newly allocated ml model id
         """
         response = self.loop.run_until_complete(
             self.send_message("register_model", {"client_id": client_id})
@@ -576,7 +557,6 @@ class WebSocketClientCommunicator(ClientCommunicator):
 
         :param client_id: client owning the model
         :param model_id: model to remove
-        :return: True if removal was successful, False otherwise
         """
         response = self.loop.run_until_complete(
             self.send_message("remove_model", {
@@ -584,14 +564,14 @@ class WebSocketClientCommunicator(ClientCommunicator):
                 "ml_model_id": model_id,
             })
         )
-        return "error" not in response
+        self._check_response_error(response)
+        return True
 
     def get_ml_models(self, client_id: str) -> List[str]:
         """
         Get all ML models registered for this specific client in the PyMiloServer.
 
         :param client_id: client whose models are being queried
-        :return: list of ml model ids
         """
         response = self.loop.run_until_complete(
             self.send_message("get_ml_models", {"client_id": client_id})
@@ -606,7 +586,6 @@ class WebSocketClientCommunicator(ClientCommunicator):
         :param allower_id: ID of the client granting access
         :param allowee_id: ID of the client being granted access
         :param model_id: ID of the model being shared
-        :return: True if successful, False otherwise
         """
         response = self.loop.run_until_complete(
             self.send_message("grant_access", {
@@ -615,7 +594,8 @@ class WebSocketClientCommunicator(ClientCommunicator):
                 "model_id": model_id,
             })
         )
-        return "error" not in response
+        self._check_response_error(response)
+        return True
 
     def revoke_access(self, revoker_id: str, revokee_id: str, model_id: str) -> bool:
         """
@@ -624,7 +604,6 @@ class WebSocketClientCommunicator(ClientCommunicator):
         :param revoker_id: ID of the client revoking access
         :param revokee_id: ID of the client whose access is being revoked
         :param model_id: ID of the model
-        :return: True if successful, False otherwise
         """
         response = self.loop.run_until_complete(
             self.send_message("revoke_access", {
@@ -633,14 +612,14 @@ class WebSocketClientCommunicator(ClientCommunicator):
                 "model_id": model_id,
             })
         )
-        return "error" not in response
+        self._check_response_error(response)
+        return True
 
-    def get_allowance(self, allower_id):
+    def get_allowance(self, allower_id: str) -> Dict[str, List[str]]:
         """
         Get the list of all allowees and their allowed models from a given allower.
 
         :param allower_id: ID of the allower
-        :return: dict of allowees to model lists
         """
         response = self.loop.run_until_complete(
             self.send_message("get_allowance", {"allower_id": allower_id})
@@ -654,7 +633,6 @@ class WebSocketClientCommunicator(ClientCommunicator):
 
         :param allower_id: ID of the model owner
         :param allowee_id: ID of the requesting client
-        :return: list of model IDs
         """
         response = self.loop.run_until_complete(
             self.send_message("get_allowed_models", {
@@ -725,12 +703,11 @@ class WebSocketServerCommunicator:
         await websocket.accept()
         self.active_connections.append(websocket)
 
-    def disconnect(self, websocket: WebSocket):
+    def disconnect(self, websocket: WebSocket) -> None:
         """
         Handle WebSocket disconnection.
 
         :param websocket: the WebSocket connection to remove.
-        :type websocket: WebSocket
         """
         self.active_connections.remove(websocket)
 
@@ -763,7 +740,6 @@ class WebSocketServerCommunicator:
         Handle client registration requests.
 
         :param payload: the payload (empty for this action).
-        :return: a response containing the newly allocated client ID.
         """
         client_id = str(uuid.uuid4())
         self._ps.init_client(client_id)
@@ -777,7 +753,6 @@ class WebSocketServerCommunicator:
         Handle client removal requests.
 
         :param payload: the payload containing the client ID to remove.
-        :return: a response indicating success or failure.
         """
         client_id = payload.get("client_id")
         is_succeed, detail_message = self._ps.remove_client(client_id)
@@ -793,7 +768,6 @@ class WebSocketServerCommunicator:
         Handle ML model registration requests.
 
         :param payload: the payload containing the client ID.
-        :return: a response containing the newly allocated model ID.
         """
         client_id = payload.get("client_id")
         ml_model_id = str(uuid.uuid4())
@@ -811,7 +785,6 @@ class WebSocketServerCommunicator:
         Handle ML model removal requests.
 
         :param payload: the payload containing the client ID and model ID.
-        :return: a response indicating success or failure.
         """
         client_id = payload.get("client_id")
         ml_model_id = payload.get("ml_model_id")
@@ -829,7 +802,6 @@ class WebSocketServerCommunicator:
         Handle requests to get all ML models for a client.
 
         :param payload: the payload containing the client ID.
-        :return: a response containing the list of model IDs.
         """
         client_id = payload.get("client_id")
         return {
@@ -843,7 +815,6 @@ class WebSocketServerCommunicator:
         Handle requests to grant model access to another client.
 
         :param payload: the payload containing allower_id, allowee_id, and model_id.
-        :return: a response indicating success or failure.
         """
         allower_id = payload.get("allower_id")
         allowee_id = payload.get("allowee_id")
@@ -863,7 +834,6 @@ class WebSocketServerCommunicator:
         Handle requests to revoke model access from another client.
 
         :param payload: the payload containing revoker_id, revokee_id, and model_id.
-        :return: a response indicating success or failure.
         """
         revoker_id = payload.get("revoker_id")
         revokee_id = payload.get("revokee_id")
@@ -883,7 +853,6 @@ class WebSocketServerCommunicator:
         Handle requests to get all allowances for a client.
 
         :param payload: the payload containing the allower_id.
-        :return: a response containing the allowance dictionary.
         """
         allower_id = payload.get("allower_id")
         allowance, reason = self._ps.get_clients_allowance(allower_id)
@@ -900,7 +869,6 @@ class WebSocketServerCommunicator:
         Handle requests to get allowed models for a specific allowee.
 
         :param payload: the payload containing allower_id and allowee_id.
-        :return: a response containing the list of allowed model IDs.
         """
         allower_id = payload.get("allower_id")
         allowee_id = payload.get("allowee_id")
@@ -919,7 +887,6 @@ class WebSocketServerCommunicator:
         Handle download requests.
 
         :param payload: the payload containing the ids associated with the requested model for download.
-        :return: a response containing the exported model.
         """
         client_id = payload.get("client_id")
         ml_model_id = payload.get("ml_model_id")
@@ -927,7 +894,7 @@ class WebSocketServerCommunicator:
         if not is_valid:
             return {"error": reason}
         return {
-            "message": f"Download request from client: {client_id} for model: {ml_model_id}",
+            "message": MSG_DOWNLOAD_REQUEST.format(client_id=client_id, ml_model_id=ml_model_id),
             "payload": self._ps.export_model(client_id, ml_model_id),
         }
 
@@ -936,7 +903,6 @@ class WebSocketServerCommunicator:
         Handle upload requests.
 
         :param payload: the payload containing the model data to upload.
-        :return: a response indicating that the upload was processed.
         """
         client_id = payload.get("client_id")
         ml_model_id = payload.get("ml_model_id")
@@ -952,7 +918,7 @@ class WebSocketServerCommunicator:
             return {"error": reason}
         self._ps.update_model(client_id, ml_model_id, model_data)
         return {
-            "message": f"Upload request from client: {client_id} for model: {ml_model_id}",
+            "message": MSG_UPLOAD_REQUEST.format(client_id=client_id, ml_model_id=ml_model_id),
         }
 
     def _handle_attribute_call(self, payload: dict) -> dict:
@@ -960,7 +926,6 @@ class WebSocketServerCommunicator:
         Handle attribute call requests.
 
         :param payload: the payload containing the attribute call details.
-        :return: a response with the result of the attribute call.
         """
         client_id = payload.get("client_id")
         ml_model_id = payload.get("ml_model_id")
@@ -973,7 +938,7 @@ class WebSocketServerCommunicator:
             return {"error": reason}
         result = self._ps.execute_model(call_payload)
         return {
-            "message": f"Attribute call request from client: {client_id} for model: {ml_model_id}",
+            "message": MSG_ATTRIBUTE_CALL_REQUEST.format(client_id=client_id, ml_model_id=ml_model_id),
             "payload": result if result else "The ML model has been updated in place.",
         }
 
@@ -982,7 +947,6 @@ class WebSocketServerCommunicator:
         Handle attribute type queries.
 
         :param payload: the payload containing the attribute to query.
-        :return: a response with the attribute type and value.
         """
         client_id = payload.get("client_id")
         ml_model_id = payload.get("ml_model_id")
@@ -995,7 +959,7 @@ class WebSocketServerCommunicator:
             return {"error": reason}
         is_callable, field_value = self._ps.is_callable_attribute(type_payload)
         return {
-            "message": f"Attribute type request from client: {client_id} for model: {ml_model_id}",
+            "message": MSG_ATTRIBUTE_TYPE_REQUEST.format(client_id=client_id, ml_model_id=ml_model_id),
             "attribute type": "method" if is_callable else "field",
             "attribute value": "" if is_callable else field_value,
         }
@@ -1005,7 +969,6 @@ class WebSocketServerCommunicator:
         Parse the encrypted and compressed message.
 
         :param message: the encrypted and compressed message to parse.
-        :return: the decrypted and extracted version of the message.
         """
         if isinstance(message, dict):
             return message

--- a/pymilo/streaming/param.py
+++ b/pymilo/streaming/param.py
@@ -12,3 +12,12 @@ PYMILO_INVALID_URL = "The given URL is not valid."
 PYMILO_CLIENT_WEBSOCKET_NOT_CONNECTED = "WebSocket is not connected."
 
 REST_API_PREFIX = "/api/v1"
+
+MSG_DOWNLOAD_REQUEST = "Download request from client: {client_id} for model: {ml_model_id}"
+MSG_UPLOAD_REQUEST = "Upload request from client: {client_id} for model: {ml_model_id}"
+MSG_ATTRIBUTE_CALL_REQUEST = "Attribute call request from client: {client_id} for model: {ml_model_id}"
+MSG_ATTRIBUTE_TYPE_REQUEST = "Attribute type request from client: {client_id} for model: {ml_model_id}"
+MSG_REST_DOWNLOAD_REQUEST = "/download request from client: {client_id} for model: {ml_model_id}"
+MSG_REST_UPLOAD_REQUEST = "/upload request from client: {client_id} for model: {ml_model_id}"
+MSG_REST_ATTRIBUTE_CALL_REQUEST = "/attribute_call request from client: {client_id} for model: {ml_model_id}"
+MSG_REST_ATTRIBUTE_TYPE_REQUEST = "/attribute_type request from client: {client_id} for model: {ml_model_id}"

--- a/pymilo/streaming/pymilo_client.py
+++ b/pymilo/streaming/pymilo_client.py
@@ -208,7 +208,7 @@ class PymiloClient:
         """
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, _exc_type, _exc_val, _exc_tb):
         """
         Exit the context manager and close the connection.
 
@@ -219,10 +219,7 @@ class PymiloClient:
 
     def __del__(self):
         """Clean up resources on object destruction."""
-        try:
-            self.close()
-        except Exception:
-            pass
+        self.close()
 
     def __getattr__(self, attribute):
         """

--- a/pymilo/streaming/pymilo_client.py
+++ b/pymilo/streaming/pymilo_client.py
@@ -191,6 +191,39 @@ class PymiloClient:
         """
         return self._communicator.get_allowed_models(allower_id, self.client_id)
 
+    def close(self):
+        """
+        Close the client connection and release resources.
+
+        :return: None
+        """
+        if hasattr(self._communicator, 'close'):
+            self._communicator.close()
+
+    def __enter__(self):
+        """
+        Enter the context manager.
+
+        :return: self
+        """
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """
+        Exit the context manager and close the connection.
+
+        :return: False
+        """
+        self.close()
+        return False
+
+    def __del__(self):
+        """Clean up resources on object destruction."""
+        try:
+            self.close()
+        except Exception:
+            pass
+
     def __getattr__(self, attribute):
         """
         Overwrite the __getattr__ default function to extract requested.

--- a/pymilo/transporters/function_transporter.py
+++ b/pymilo/transporters/function_transporter.py
@@ -8,10 +8,14 @@ from numpy import ufunc
 
 array_function_dispatcher_support = False
 try:
-    from numpy.core._multiarray_umath import _ArrayFunctionDispatcher
+    from numpy._core._multiarray_umath import _ArrayFunctionDispatcher
     array_function_dispatcher_support = True
-except BaseException:
-    pass
+except ImportError:
+    try:
+        from numpy.core._multiarray_umath import _ArrayFunctionDispatcher
+        array_function_dispatcher_support = True
+    except ImportError:
+        pass
 
 
 class FunctionTransporter(AbstractTransporter):

--- a/tests/test_ml_streaming/run_server.py
+++ b/tests/test_ml_streaming/run_server.py
@@ -26,16 +26,23 @@ def main():
         default=False,
         help='the `init` command specifies whether or not initializing the PyMilo Server with a ML model.',
     )
+    parser.add_argument(
+        '--port',
+        type=int,
+        default=None,
+        help='Override the default port.',
+    )
     args = parser.parse_args()
     communicator = None
     if args.init:
+        port = args.port if args.port else 9000
         x_train, y_train, _, _ = prepare_simple_regression_datasets()
         linear_regression = LinearRegression()
         linear_regression.fit(x_train, y_train)
         ps = PymiloServer(
-            port=9000,
+            port=port,
             compressor=Compression[args.compression],
-            communication_protocol= CommunicationProtocol[args.protocol],
+            communication_protocol=CommunicationProtocol[args.protocol],
             )
         sample_client_id = "0x_demo_client_id"
         sample_ml_model_id = "0x_demo_ml_model_id"
@@ -44,8 +51,9 @@ def main():
         ps.set_ml_model(sample_client_id, sample_ml_model_id, linear_regression)
         communicator = ps.communicator
     else:
+        port = args.port if args.port else 8000
         communicator = PymiloServer(
-            port=8000,
+            port=port,
             compressor=Compression[args.compression],
             communication_protocol=CommunicationProtocol[args.protocol],
             ).communicator

--- a/tests/test_ml_streaming/scenarios/scenario1.py
+++ b/tests/test_ml_streaming/scenarios/scenario1.py
@@ -44,4 +44,9 @@ def scenario1(compression_method, communication_protocol):
     # 7.
     result = client.predict(x_test)
     mse_after = mean_squared_error(y_test, result)
+
+    # Clean up WebSocket connection if applicable
+    if hasattr(client._communicator, 'close'):
+        client._communicator.close()
+
     return np.abs(mse_after-mse_before)

--- a/tests/test_ml_streaming/scenarios/scenario1.py
+++ b/tests/test_ml_streaming/scenarios/scenario1.py
@@ -45,8 +45,4 @@ def scenario1(compression_method, communication_protocol):
     result = client.predict(x_test)
     mse_after = mean_squared_error(y_test, result)
 
-    # Clean up WebSocket connection if applicable
-    if hasattr(client._communicator, 'close'):
-        client._communicator.close()
-
     return np.abs(mse_after-mse_before)

--- a/tests/test_ml_streaming/scenarios/scenario2.py
+++ b/tests/test_ml_streaming/scenarios/scenario2.py
@@ -49,4 +49,9 @@ def scenario2(compression_method, communication_protocol):
     local_field = client.coef_
     result = client.predict(x_test)
     mse_local = mean_squared_error(y_test, result)
+
+    # Clean up WebSocket connection if applicable
+    if hasattr(client._communicator, 'close'):
+        client._communicator.close()
+
     return np.abs(mse_server-mse_local) + np.abs(np.sum(local_field-remote_field))

--- a/tests/test_ml_streaming/scenarios/scenario2.py
+++ b/tests/test_ml_streaming/scenarios/scenario2.py
@@ -50,8 +50,4 @@ def scenario2(compression_method, communication_protocol):
     result = client.predict(x_test)
     mse_local = mean_squared_error(y_test, result)
 
-    # Clean up WebSocket connection if applicable
-    if hasattr(client._communicator, 'close'):
-        client._communicator.close()
-
     return np.abs(mse_server-mse_local) + np.abs(np.sum(local_field-remote_field))

--- a/tests/test_ml_streaming/scenarios/scenario3.py
+++ b/tests/test_ml_streaming/scenarios/scenario3.py
@@ -34,8 +34,5 @@ def scenario3(compression_method, communication_protocol):
     result = client.predict(x_test)
     mse_local = mean_squared_error(y_test, result)
 
-    # 4. Clean up WebSocket connection if applicable
-    if hasattr(client._communicator, 'close'):
-        client._communicator.close()
-
+    # 4.
     return np.abs(mse_server-mse_local)

--- a/tests/test_ml_streaming/scenarios/scenario3.py
+++ b/tests/test_ml_streaming/scenarios/scenario3.py
@@ -34,5 +34,8 @@ def scenario3(compression_method, communication_protocol):
     result = client.predict(x_test)
     mse_local = mean_squared_error(y_test, result)
 
-    # 4.
+    # 4. Clean up WebSocket connection if applicable
+    if hasattr(client._communicator, 'close'):
+        client._communicator.close()
+
     return np.abs(mse_server-mse_local)

--- a/tests/test_ml_streaming/scenarios/scenario4.py
+++ b/tests/test_ml_streaming/scenarios/scenario4.py
@@ -1,0 +1,91 @@
+from pymilo.streaming import PymiloClient, Compression, CommunicationProtocol
+from sklearn.linear_model import LinearRegression
+from pymilo.utils.data_exporter import prepare_simple_regression_datasets
+
+
+def scenario4(compression_method, communication_protocol):
+    """
+    Test access control management features between multiple clients.
+
+    This scenario tests:
+    1. Client registration/deregistration
+    2. Model registration/deregistration
+    3. get_ml_models
+    4. grant_access / revoke_access
+    5. get_allowance / get_allowed_models
+    """
+    x_train, y_train, _, _ = prepare_simple_regression_datasets()
+
+    # Create and train a model locally
+    linear_regression = LinearRegression()
+    linear_regression.fit(x_train, y_train)
+
+    # Initialize client_a (model owner)
+    client_a = PymiloClient(
+        model=linear_regression,
+        mode=PymiloClient.Mode.LOCAL,
+        compressor=Compression[compression_method],
+        server_url="127.0.0.1:8500",
+        communication_protocol=CommunicationProtocol[communication_protocol],
+    )
+
+    # Initialize client_b (will be granted access)
+    client_b = PymiloClient(
+        mode=PymiloClient.Mode.LOCAL,
+        compressor=Compression[compression_method],
+        server_url="127.0.0.1:8500",
+        communication_protocol=CommunicationProtocol[communication_protocol],
+    )
+
+    # 1. Register both clients
+    client_a.register()
+    client_b.register()
+
+    assert client_a.client_id is not None, "client_a registration failed"
+    assert client_b.client_id is not None, "client_b registration failed"
+    assert client_a.client_id != client_b.client_id, "clients should have different IDs"
+
+    # 2. Register model for client_a
+    client_a.register_ml_model()
+    assert client_a.ml_model_id is not None, "model registration failed"
+
+    # 3. Test get_ml_models
+    models_a = client_a.get_ml_models()
+    assert client_a.ml_model_id in models_a, "registered model should appear in get_ml_models"
+
+    # 4. Upload model from client_a
+    client_a.upload()
+
+    # 5. Grant access from client_a to client_b (uses client_a.ml_model_id implicitly)
+    grant_result = client_a.grant_access(client_b.client_id)
+    assert grant_result is True, "grant_access should succeed"
+
+    # 6. Verify allowance updated
+    allowance = client_a.get_allowance()
+    assert isinstance(allowance, dict), "get_allowance should return a dict"
+    assert client_b.client_id in allowance, "client_b should be in allowance after grant"
+    assert client_a.ml_model_id in allowance[client_b.client_id], "model should be in allowance"
+
+    # 7. Test get_allowed_models (from client_b's perspective)
+    allowed_models = client_b.get_allowed_models(client_a.client_id)
+    assert client_a.ml_model_id in allowed_models, "model should be in allowed_models"
+
+    # 8. Revoke access (uses client_a.ml_model_id implicitly)
+    revoke_result = client_a.revoke_access(client_b.client_id)
+    assert revoke_result is True, "revoke_access should succeed"
+
+    # 9. Verify allowance updated after revoke
+    allowed_models_after_revoke = client_b.get_allowed_models(client_a.client_id)
+    assert client_a.ml_model_id not in allowed_models_after_revoke, "model should not be in allowed_models after revoke"
+
+    # 10. Test model deregistration
+    models_before_deregister = client_a.get_ml_models()
+    client_a.deregister_ml_model()
+    models_after_deregister = client_a.get_ml_models()
+    assert len(models_after_deregister) == len(models_before_deregister) - 1, "model count should decrease after deregister"
+
+    # 11. Test client deregistration
+    client_b.deregister()
+    client_a.deregister()
+
+    return 0

--- a/tests/test_ml_streaming/scenarios/scenario4.py
+++ b/tests/test_ml_streaming/scenarios/scenario4.py
@@ -88,4 +88,10 @@ def scenario4(compression_method, communication_protocol):
     client_b.deregister()
     client_a.deregister()
 
+    # 12. Clean up WebSocket connections if applicable
+    if hasattr(client_a._communicator, 'close'):
+        client_a._communicator.close()
+    if hasattr(client_b._communicator, 'close'):
+        client_b._communicator.close()
+
     return 0

--- a/tests/test_ml_streaming/scenarios/scenario4.py
+++ b/tests/test_ml_streaming/scenarios/scenario4.py
@@ -88,10 +88,4 @@ def scenario4(compression_method, communication_protocol):
     client_b.deregister()
     client_a.deregister()
 
-    # 12. Clean up WebSocket connections if applicable
-    if hasattr(client_a._communicator, 'close'):
-        client_a._communicator.close()
-    if hasattr(client_b._communicator, 'close'):
-        client_b._communicator.close()
-
     return 0

--- a/tests/test_ml_streaming/test_streaming.py
+++ b/tests/test_ml_streaming/test_streaming.py
@@ -60,7 +60,7 @@ def prepare_ml_server(request):
     #         "--protocol", communication_protocol,
     #         "--port", "9000",
     #         "--load", os.path.join(os.getcwd(), "tests", "test_exceptions", "valid_jsons", "linear_regression.json")
-    #         # "--load", "https://raw.githubusercontent.com/openscilab/pymilo/main/tests/test_exceptions/valid_jsons", "linear_regression.json",
+    #         # "--load", "https://raw.githubusercontent.com/openscilab/pymilo/main/tests/test_exceptions/valid_jsons/linear_regression.json",
     #     ],
     #     )
     path = os.path.join(

--- a/tests/test_ml_streaming/test_streaming.py
+++ b/tests/test_ml_streaming/test_streaming.py
@@ -7,6 +7,7 @@ from sys import executable
 from scenarios.scenario1 import scenario1
 from scenarios.scenario2 import scenario2
 from scenarios.scenario3 import scenario3
+from scenarios.scenario4 import scenario4
 from pymilo.streaming.util import generate_dockerfile
 
 @pytest.fixture(
@@ -59,7 +60,7 @@ def prepare_ml_server(request):
     #         "--protocol", communication_protocol,
     #         "--port", "9000",
     #         "--load", os.path.join(os.getcwd(), "tests", "test_exceptions", "valid_jsons", "linear_regression.json")
-    #         # "--load", "https://raw.githubusercontent.com/openscilab/pymilo/main/tests/test_exceptions/valid_jsons/linear_regression.json",
+    #         # "--load", "https://raw.githubusercontent.com/openscilab/pymilo/main/tests/test_exceptions/valid_jsons", "linear_regression.json",
     #     ],
     #     )
     path = os.path.join(
@@ -82,6 +83,33 @@ def prepare_ml_server(request):
     server_proc.terminate()
 
 
+@pytest.fixture(
+    scope="function",
+    params=["REST", "WEBSOCKET"])
+def prepare_access_control_server(request):
+    communication_protocol = request.param
+    compression_method = "ZLIB"
+    path = os.path.join(
+        os.getcwd(),
+        "tests",
+        "test_ml_streaming",
+        "run_server.py",
+        )
+    server_proc = subprocess.Popen(
+        [
+            executable,
+            path,
+            "--compression", compression_method,
+            "--protocol", communication_protocol,
+            "--port", "8500",
+        ],
+        )
+    time.sleep(10)
+    yield (compression_method, communication_protocol)
+    server_proc.terminate()
+    time.sleep(2)
+
+
 def test1(prepare_bare_server):
     compression_method, communication_protocol = prepare_bare_server
     assert scenario1(compression_method, communication_protocol) == 0
@@ -95,6 +123,11 @@ def test2(prepare_bare_server):
 def test3(prepare_ml_server):
     compression_method, communication_protocol = prepare_ml_server
     assert scenario3(compression_method, communication_protocol) == 0
+
+
+def test4(prepare_access_control_server):
+    compression_method, communication_protocol = prepare_access_control_server
+    assert scenario4(compression_method, communication_protocol) == 0
 
 
 def test_dockerfile():

--- a/tests/test_ml_streaming/test_streaming.py
+++ b/tests/test_ml_streaming/test_streaming.py
@@ -46,7 +46,7 @@ def prepare_bare_server(request):
 
 @pytest.fixture(
     scope="session",
-    params=["REST",]) #"WEBSOCKET"])
+    params=["REST", "WEBSOCKET"])
 def prepare_ml_server(request):
     communication_protocol = request.param
     compression_method = "ZLIB"


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement/fix? Explain your changes.
- Aligned WebSocket protocol with REST API (client registration, model management, access control)
- Added `scenario4` test for access control features on both protocols
- Fixed REST `get_allowance` returning 404 on empty allowances
- Fixed numpy and datetime deprecation warnings
- Added proper connection cleanup to `PymiloClient` and `WebSocketClientCommunicator`

#### Any other comments?

